### PR TITLE
chore: fixes node14 target ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run compile
 
       - name: Run Tests
-        run: npm --ignore-scripts test -- -c -t0
+        run: npx c8 tap -c -t0
         timeout-minutes: 5
 
   lint:


### PR DESCRIPTION
It looks like my node14 ci target is not running tests at the moment
given that node14 ships with npm6 which doesn't have support to the
syntax used here.

This changeset fixes it by invoking the direct commands to run the tests
instead of using `npm test`.