### PR TITLE
chore: add `SQLAdminFetcher` class and `getInstanceMetadata`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
       "name": "@google-cloud/cloud-sql-connector",
       "version": "0.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@googleapis/sqladmin": "^6.1.0",
+        "google-auth-library": "^8.7.0"
+      },
       "devDependencies": {
         "@types/node": "^14.11.2",
-        "@types/tap": "^15.0.7",
+        "@types/tap": "^15.0.8",
         "c8": "^7.12.0",
         "gts": "^3.1.1",
+        "nock": "^13.3.0",
         "tap": "^16.3.4",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
@@ -540,6 +545,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@googleapis/sqladmin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-6.1.0.tgz",
+      "integrity": "sha512-3l2EQQtnO9SyRREeRerU/mJTqZLi0ebi4+B//MligoFGNaGPkiLCScTIxXE0lCjh6svdZW3cDlpeeT4ryPmYVg==",
+      "dependencies": {
+        "googleapis-common": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -783,9 +799,9 @@
       "dev": true
     },
     "node_modules/@types/tap": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/@types/tap/-/tap-15.0.7.tgz",
-      "integrity": "sha512-TTMajw4gxQfFgYbhXhy/Tb2OiNcwS+4oP/9yp1/GdU0pFJo3wtnkYhRgmQy39ksh+rnoa0VrPHJ4Tuv2cLNQ5A==",
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/@types/tap/-/tap-15.0.8.tgz",
+      "integrity": "sha512-ZfeoiZlLIaFi4t6wccwbTEicrHREkP0bOq8dZVi/nWvG5F8O7LlS2cSUZBiOW/D4cgWS/p2uhM3lJoyzFAl80w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -978,6 +994,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1155,6 +1182,33 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1223,6 +1277,11 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1268,6 +1327,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1480,7 +1551,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1579,6 +1649,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2025,6 +2103,11 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -2078,6 +2161,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2256,8 +2344,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function-loop": {
       "version": "2.0.1",
@@ -2270,6 +2357,32 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "node_modules/gaxios": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.2.tgz",
+      "integrity": "sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.2.0.tgz",
+      "integrity": "sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2287,6 +2400,19 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -2377,11 +2503,89 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.7.0.tgz",
+      "integrity": "sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-6.0.4.tgz",
+      "integrity": "sha512-m4ErxGE8unR1z0VajT6AYk3s6a9gIMM6EkDZfkPnES8joeOlEtFEJeF8IyZkb0tjPXkktUfYrE4b3Li1DNyOwA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^5.0.1",
+        "google-auth-library": "^8.0.2",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/gts": {
       "version": "3.1.1",
@@ -2428,7 +2632,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2443,6 +2646,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasha": {
@@ -2487,6 +2701,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -2674,7 +2900,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -2849,6 +3074,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2867,6 +3100,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2877,6 +3116,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -2977,7 +3235,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3164,8 +3421,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -3186,6 +3442,48 @@
       "dev": true,
       "bin": {
         "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-preload": {
@@ -3408,6 +3706,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -3761,6 +4067,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3768,6 +4083,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -4109,6 +4438,25 @@
         "npm": ">=2.0.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4155,6 +4503,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6479,6 +6840,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -6660,6 +7026,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6703,6 +7074,20 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6782,8 +7167,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
   },
   "devDependencies": {
     "@types/node": "^14.11.2",
-    "@types/tap": "^15.0.7",
+    "@types/tap": "^15.0.8",
     "c8": "^7.12.0",
     "gts": "^3.1.1",
+    "nock": "^13.3.0",
     "tap": "^16.3.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
@@ -59,5 +60,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector"
+  },
+  "dependencies": {
+    "@googleapis/sqladmin": "^6.1.0",
+    "google-auth-library": "^8.7.0"
   }
 }

--- a/src/instance-connection-info.ts
+++ b/src/instance-connection-info.ts
@@ -1,0 +1,19 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface InstanceConnectionInfo {
+  projectId: string;
+  regionId: string;
+  instanceId: string;
+}

--- a/src/parse-instance-connection-name.ts
+++ b/src/parse-instance-connection-name.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-interface InstanceConnectionInfo {
-  projectId: string;
-  regionId: string;
-  instanceId: string;
-}
+import {InstanceConnectionInfo} from './instance-connection-info';
 
 const missingInstanceConnectionNameError = () =>
   Object.assign(

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -1,0 +1,146 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GoogleAuth} from 'google-auth-library';
+import {sqladmin_v1beta4} from '@googleapis/sqladmin';
+const {Sqladmin} = sqladmin_v1beta4;
+import {InstanceConnectionInfo} from './instance-connection-info';
+
+interface IpAdresses {
+  public?: string;
+  private?: string;
+}
+
+type SslCert = Pick<sqladmin_v1beta4.Schema$SslCert, 'cert' | 'expirationTime'>;
+
+interface InstanceMetadata {
+  ipAddresses: IpAdresses;
+  serverCaCert: SslCert;
+}
+
+const noResponseDataError = (projectId: string, instanceId: string) =>
+  Object.assign(
+    new Error(
+      `Failed to find metadata on project id: ${projectId} ` +
+        `and instance id: ${instanceId}. Ensure network connectivity and ` +
+        'validate the provided `instanceConnectionName` config value'
+    ),
+    {code: 'ENOSQLADMIN'}
+  );
+
+const noCertError = () =>
+  Object.assign(
+    new Error('Cannot connect to instance, no valid CA certificate found'),
+    {
+      code: 'ENOSQLADMINCERT',
+    }
+  );
+
+const noIpAddressError = () =>
+  Object.assign(
+    new Error('Cannot connect to instance, it has no supported IP addresses'),
+    {
+      code: 'ENOSQLADMINIPADDRESS',
+    }
+  );
+
+const noRegionError = () =>
+  Object.assign(
+    new Error('Cannot connect to instance, no valid region found'),
+    {
+      code: 'ENOSQLADMINREGION',
+    }
+  );
+
+const regionMismatchError = (regionResult: string, regionId: string) =>
+  Object.assign(
+    new Error(
+      `Provided region was mismatched. Got ${regionResult}, want ${regionId}`
+    ),
+    {
+      code: 'EBADSQLADMINREGION',
+    }
+  );
+
+const parseIpAddresses = (
+  ipResponse: sqladmin_v1beta4.Schema$IpMapping[]
+): IpAdresses => {
+  const ipAddresses: IpAdresses = {};
+  for (const ip of ipResponse) {
+    if (ip.type === 'PRIMARY' && ip.ipAddress) {
+      ipAddresses.public = ip.ipAddress;
+    }
+    if (ip.type === 'PRIVATE' && ip.ipAddress) {
+      ipAddresses.private = ip.ipAddress;
+    }
+  }
+
+  if (!ipAddresses.public && !ipAddresses.private) {
+    throw noIpAddressError();
+  }
+
+  return ipAddresses;
+};
+
+export class SQLAdminFetcher {
+  private readonly client: sqladmin_v1beta4.Sqladmin;
+
+  constructor() {
+    const auth = new GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
+    });
+    this.client = new Sqladmin({auth});
+  }
+
+  async getInstanceMetadata({
+    projectId,
+    regionId,
+    instanceId,
+  }: InstanceConnectionInfo): Promise<InstanceMetadata> {
+    const res = await this.client.connect.get({
+      project: projectId,
+      instance: instanceId,
+    });
+
+    if (!res.data) {
+      throw noResponseDataError(projectId, instanceId);
+    }
+
+    if (!res.data.ipAddresses) {
+      throw noIpAddressError();
+    }
+    const ipAddresses = parseIpAddresses(res.data.ipAddresses);
+
+    const {serverCaCert} = res.data;
+    if (!serverCaCert || !serverCaCert.cert) {
+      throw noCertError();
+    }
+
+    const {region} = res.data;
+    if (!region) {
+      throw noRegionError();
+    }
+    if (region !== regionId) {
+      throw regionMismatchError(region, regionId);
+    }
+
+    return {
+      ipAddresses,
+      serverCaCert: {
+        cert: serverCaCert.cert,
+        expirationTime: serverCaCert.expirationTime,
+      },
+    };
+  }
+}

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -1,0 +1,274 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import t from 'tap';
+import nock from 'nock';
+import {sqladmin_v1beta4} from '@googleapis/sqladmin';
+import {SQLAdminFetcher} from '../src/sqladmin-fetcher';
+import {InstanceConnectionInfo} from '../src/instance-connection-info';
+
+const setupCredentials = (test: Tap.Test): void => {
+  const path = test.testdir({
+    credentials: JSON.stringify({
+      client_secret: 'privatekey',
+      client_id: 'client123',
+      refresh_token: 'refreshtoken',
+      type: 'authorized_user',
+    }),
+  });
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = resolve(path, 'credentials');
+  test.teardown(() => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = undefined;
+  });
+
+  nock('https://oauth2.googleapis.com')
+    .post('/token')
+    .reply(200, {access_token: 'abc123', expires_in: 1});
+};
+
+const mockRequest = (
+  instanceInfo: InstanceConnectionInfo,
+  overrides?: sqladmin_v1beta4.Schema$ConnectSettings
+): void => {
+  const {projectId, regionId, instanceId} = instanceInfo;
+
+  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
+    .get(`/${projectId}/instances/${instanceId}/connectSettings`)
+    .reply(200, {
+      kind: 'sql#connectSettings',
+      serverCaCert: {
+        kind: 'sql#sslCert',
+        certSerialNumber: '0',
+        cert: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
+        commonName:
+          'C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=1234',
+        sha1Fingerprint: '004fe8623f02cb953bb5addbd0309f3b8f136c00',
+        instance: instanceId,
+        createTime: '2023-01-01T10:00:00.232Z',
+        expirationTime: '2033-01-06T10:00:00.232Z',
+      },
+      ipAddresses: [
+        {
+          type: 'PRIMARY',
+          ipAddress: '0.0.0.0',
+        },
+        {
+          type: 'OUTGOING',
+          ipAddress: '0.0.0.1',
+        },
+      ],
+      region: regionId,
+      databaseVersion: 'POSTGRES_14',
+      backendType: 'SECOND_GEN',
+      // overrides any properties from the base mock
+      ...overrides,
+    });
+};
+
+t.test('getInstanceMetadata', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'my-project',
+    regionId: 'us-east1',
+    instanceId: 'my-instance',
+  };
+  mockRequest(instanceConnectionInfo);
+
+  const fetcher = new SQLAdminFetcher();
+  const instanceMetadata = await fetcher.getInstanceMetadata(
+    instanceConnectionInfo
+  );
+  t.same(
+    instanceMetadata,
+    {
+      ipAddresses: {
+        public: '0.0.0.0',
+      },
+      serverCaCert: {
+        cert: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
+        expirationTime: '2033-01-06T10:00:00.232Z',
+      },
+    },
+    'should return expected instance metadata object'
+  );
+});
+
+t.test('getInstanceMetadata private ip', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'private-ip-project',
+    regionId: 'us-east1',
+    instanceId: 'private-ip-instance',
+  };
+  mockRequest(instanceConnectionInfo, {
+    ipAddresses: [
+      {
+        type: 'PRIVATE',
+        ipAddress: '0.0.0.0',
+      },
+    ],
+  });
+
+  const fetcher = new SQLAdminFetcher();
+  const instanceMetadata = await fetcher.getInstanceMetadata(
+    instanceConnectionInfo
+  );
+  t.match(
+    instanceMetadata,
+    {
+      ipAddresses: {
+        private: '0.0.0.0',
+      },
+    },
+    'should return expected instance metadata containing private ip'
+  );
+});
+
+t.test('getInstanceMetadata no valid ip addresses', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'no-ip-project',
+    regionId: 'us-east1',
+    instanceId: 'no-ip-instance',
+  };
+  mockRequest(instanceConnectionInfo, {
+    ipAddresses: [
+      {
+        type: 'OUTGOING',
+        ipAddress: '0.0.0.1',
+      },
+    ],
+  });
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      code: 'ENOSQLADMINIPADDRESS',
+    },
+    'should throw no ip address error'
+  );
+});
+
+t.test('getInstanceMetadata no valid cert', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'no-cert-project',
+    regionId: 'us-east1',
+    instanceId: 'no-cert-instance',
+  };
+  mockRequest(instanceConnectionInfo, {
+    serverCaCert: {},
+  });
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      code: 'ENOSQLADMINCERT',
+    },
+    'should throw no cert error'
+  );
+});
+
+t.test('getInstanceMetadata no response data', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'no-response-data-project',
+    regionId: 'us-east1',
+    instanceId: 'no-response-data-instance',
+  };
+  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
+    .get(
+      '/no-response-data-project/instances/no-response-data-instance/connectSettings'
+    )
+    .reply(200, '');
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      message:
+        'Failed to find metadata on project id: no-response-data-project and instance id: no-response-data-instance. Ensure network connectivity and validate the provided `instanceConnectionName` config value',
+      code: 'ENOSQLADMIN',
+    },
+    'should throw no response data error'
+  );
+});
+
+t.test('getInstanceMetadata invalid response data', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'invalid-project',
+    regionId: 'us-east1',
+    instanceId: 'invalid-instance',
+  };
+  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
+    .get('/invalid-project/instances/invalid-instance/connectSettings')
+    .reply(200, {foo: 'bar'});
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      code: 'ENOSQLADMINIPADDRESS',
+    },
+    'should throw on invalid response data'
+  );
+});
+
+t.test('getInstanceMetadata no valid region', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'no-region-project',
+    regionId: 'us-east1',
+    instanceId: 'no-region-instance',
+  };
+  mockRequest(instanceConnectionInfo, {
+    region: undefined,
+  });
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      code: 'ENOSQLADMINREGION',
+    },
+    'should throw no region found error'
+  );
+});
+
+t.test('getInstanceMetadata invalid region', async t => {
+  setupCredentials(t);
+  const instanceConnectionInfo: InstanceConnectionInfo = {
+    projectId: 'invalid-region-project',
+    regionId: 'us-east1',
+    instanceId: 'invalid-region-instance',
+  };
+  mockRequest(instanceConnectionInfo, {
+    region: 'something-else',
+  });
+
+  const fetcher = new SQLAdminFetcher();
+  t.rejects(
+    fetcher.getInstanceMetadata(instanceConnectionInfo),
+    {
+      message:
+        'Provided region was mismatched. Got something-else, want us-east1',
+      code: 'EBADSQLADMINREGION',
+    },
+    'should throw invalid region error'
+  );
+});


### PR DESCRIPTION
Adds a `SQLAdminFetcher` class that handles GCP authentication using the `google-auth-library` package. This new class should be responsible for performing the requests to the **Cloud SQL Admin APIs**, for now only the method for retrieving instance metadata is implemented (`getInstanceMetadata`) that reaches to the `/connectSettings` endpoint to retrieve the ip address and CA certificate info.

This changeset also adds the `nock` library as a dev dependency in order to mock network calls in unit tests.
