### PR TITLE
chore: fix esm transpilation

### DIFF
--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig-base.json",
   "exclude": ["./test", "./tap-snapshots"],
   "compilerOptions": {
-    "module": "esnext",
+    "module": "node16",
     "outDir": "dist/mjs"
   }
 }


### PR DESCRIPTION
Trying to use npm packages result in a TypeScript transpilation error. This changeset fixes it by using a specific `node16` target for the compiler options.
