### PR TITLE
chore: refactor ssl cert

### DIFF
--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -16,13 +16,12 @@ import {GoogleAuth} from 'google-auth-library';
 import {sqladmin_v1beta4} from '@googleapis/sqladmin';
 const {Sqladmin} = sqladmin_v1beta4;
 import {InstanceConnectionInfo} from './instance-connection-info';
+import {SslCert} from './ssl-cert';
 
 interface IpAdresses {
   public?: string;
   private?: string;
 }
-
-type SslCert = Pick<sqladmin_v1beta4.Schema$SslCert, 'cert' | 'expirationTime'>;
 
 interface InstanceMetadata {
   ipAddresses: IpAdresses;
@@ -133,7 +132,7 @@ export class SQLAdminFetcher {
     const ipAddresses = parseIpAddresses(res.data.ipAddresses);
 
     const {serverCaCert} = res.data;
-    if (!serverCaCert || !serverCaCert.cert) {
+    if (!serverCaCert || !serverCaCert.cert || !serverCaCert.expirationTime) {
       throw noCertError();
     }
 
@@ -171,7 +170,11 @@ export class SQLAdminFetcher {
     }
 
     const {ephemeralCert} = res.data;
-    if (!ephemeralCert) {
+    if (
+      !ephemeralCert ||
+      !ephemeralCert.cert ||
+      !ephemeralCert.expirationTime
+    ) {
       throw noEphemeralCertError();
     }
 

--- a/src/ssl-cert.ts
+++ b/src/ssl-cert.ts
@@ -1,0 +1,18 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface SslCert {
+  cert: string;
+  expirationTime: string;
+}


### PR DESCRIPTION
Makes it so that the interface that defines a `SslCert` is more strict so that `cert` and `expirationTime` values can not be null. Also defines it as a separated module to help make it reusable across modules.