### PR TITLE
chore: refactor ip addresses

### DIFF
--- a/src/ip-addresses.ts
+++ b/src/ip-addresses.ts
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {sqladmin_v1beta4} from '@googleapis/sqladmin';
+
+export interface IpAdresses {
+  public?: string;
+  private?: string;
+}
+
+export const noIpAddressError = () =>
+  Object.assign(
+    new Error('Cannot connect to instance, it has no supported IP addresses'),
+    {
+      code: 'ENOSQLADMINIPADDRESS',
+    }
+  );
+
+export function parseIpAddresses(
+  ipResponse: sqladmin_v1beta4.Schema$IpMapping[] | undefined
+): IpAdresses {
+  if (!ipResponse) {
+    throw noIpAddressError();
+  }
+
+  const ipAddresses: IpAdresses = {};
+  for (const ip of ipResponse) {
+    if (ip.type === 'PRIMARY' && ip.ipAddress) {
+      ipAddresses.public = ip.ipAddress;
+    }
+    if (ip.type === 'PRIVATE' && ip.ipAddress) {
+      ipAddresses.private = ip.ipAddress;
+    }
+  }
+
+  if (!ipAddresses.public && !ipAddresses.private) {
+    throw noIpAddressError();
+  }
+
+  return ipAddresses;
+}

--- a/test/ip-addresses.ts
+++ b/test/ip-addresses.ts
@@ -1,0 +1,97 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import {parseIpAddresses} from '../src/ip-addresses';
+
+t.throws(
+  () => parseIpAddresses(undefined),
+  {code: 'ENOSQLADMINIPADDRESS'},
+  'should throw if no argument'
+);
+
+t.throws(
+  () => parseIpAddresses([]),
+  {code: 'ENOSQLADMINIPADDRESS'},
+  'should throw if no ip is found'
+);
+
+t.same(
+  parseIpAddresses([
+    {
+      ipAddress: '0.0.0.0',
+      type: 'PRIMARY',
+    },
+  ]),
+  {
+    public: '0.0.0.0',
+  },
+  'should return a public ip successfully'
+);
+
+t.same(
+  parseIpAddresses([
+    {
+      ipAddress: '0.0.0.0',
+      type: 'PRIMARY',
+    },
+    {
+      ipAddress: '0.0.0.1',
+      type: 'OUTGOING',
+    },
+  ]),
+  {
+    public: '0.0.0.0',
+  },
+  'should return a public ip from a list'
+);
+
+t.same(
+  parseIpAddresses([
+    {
+      ipAddress: '0.0.0.2',
+      type: 'PRIVATE',
+    },
+    {
+      ipAddress: '0.0.0.1',
+      type: 'OUTGOING',
+    },
+  ]),
+  {
+    private: '0.0.0.2',
+  },
+  'should return a private ip from a list'
+);
+
+t.same(
+  parseIpAddresses([
+    {
+      ipAddress: '0.0.0.0',
+      type: 'PRIMARY',
+    },
+    {
+      ipAddress: '0.0.0.2',
+      type: 'PRIVATE',
+    },
+    {
+      ipAddress: '0.0.0.1',
+      type: 'OUTGOING',
+    },
+  ]),
+  {
+    private: '0.0.0.2',
+    public: '0.0.0.0',
+  },
+  'should return a both public and private ips if available'
+);

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -138,32 +138,6 @@ t.test('getInstanceMetadata private ip', async t => {
   );
 });
 
-t.test('getInstanceMetadata no valid ip addresses', async t => {
-  setupCredentials(t);
-  const instanceConnectionInfo: InstanceConnectionInfo = {
-    projectId: 'no-ip-project',
-    regionId: 'us-east1',
-    instanceId: 'no-ip-instance',
-  };
-  mockRequest(instanceConnectionInfo, {
-    ipAddresses: [
-      {
-        type: 'OUTGOING',
-        ipAddress: '0.0.0.1',
-      },
-    ],
-  });
-
-  const fetcher = new SQLAdminFetcher();
-  t.rejects(
-    fetcher.getInstanceMetadata(instanceConnectionInfo),
-    {
-      code: 'ENOSQLADMINIPADDRESS',
-    },
-    'should throw no ip address error'
-  );
-});
-
 t.test('getInstanceMetadata no valid cert', async t => {
   setupCredentials(t);
   const instanceConnectionInfo: InstanceConnectionInfo = {
@@ -207,27 +181,6 @@ t.test('getInstanceMetadata no response data', async t => {
       code: 'ENOSQLADMIN',
     },
     'should throw no response data error'
-  );
-});
-
-t.test('getInstanceMetadata invalid response data', async t => {
-  setupCredentials(t);
-  const instanceConnectionInfo: InstanceConnectionInfo = {
-    projectId: 'invalid-project',
-    regionId: 'us-east1',
-    instanceId: 'invalid-instance',
-  };
-  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
-    .get('/invalid-project/instances/invalid-instance/connectSettings')
-    .reply(200, {foo: 'bar'});
-
-  const fetcher = new SQLAdminFetcher();
-  t.rejects(
-    fetcher.getInstanceMetadata(instanceConnectionInfo),
-    {
-      code: 'ENOSQLADMINIPADDRESS',
-    },
-    'should throw on invalid response data'
   );
 });
 


### PR DESCRIPTION
Moves the `IpAddresses` interface to its own module along with the `parseIpAddresses` function that extracts the value we want to hold in the connector out of the instance metadata response.

The goal is to make this interface easier to reuse across modules but a side effect of this change is that we're also able to move unit tests that check the parse ip addresses logic out of the `nock` based tests used in `sqladmin-fetcher` which are slower to run.
