### PR TITLE
chore: add connector instance

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {IpAdressesTypes, selectIpAddress} from './ip-addresses';
+import {InstanceConnectionInfo} from './instance-connection-info';
+import {parseInstanceConnectionName} from './parse-instance-connection-name';
+import {InstanceMetadata} from './sqladmin-fetcher';
+import {generateKeys, RSAKeys} from './generate-keys';
+import {SslCert} from './ssl-cert';
+
+interface Fetcher {
+  getInstanceMetadata({
+    projectId,
+    regionId,
+    instanceId,
+  }: InstanceConnectionInfo): Promise<InstanceMetadata>;
+  getEphemeralCertificate(
+    instanceConnectionInfo: InstanceConnectionInfo,
+    publicKey: string
+  ): Promise<SslCert>;
+}
+
+interface CloudSQLInstanceOptions {
+  connectionType: IpAdressesTypes;
+  instanceConnectionName: string;
+  sqlAdminFetcher: Fetcher;
+}
+
+export class CloudSQLInstance {
+  static async getCloudSQLInstance(
+    options: CloudSQLInstanceOptions
+  ): Promise<CloudSQLInstance> {
+    const instance = new CloudSQLInstance(options);
+    await instance.init();
+    return instance;
+  }
+
+  private readonly connectionType: IpAdressesTypes;
+  private readonly sqlAdminFetcher: Fetcher;
+  public readonly connectionInfo: InstanceConnectionInfo;
+  public ephemeralCert?: SslCert;
+  public host?: string;
+  public privateKey?: string;
+  public serverCaCert?: SslCert;
+
+  constructor({
+    connectionType,
+    instanceConnectionName,
+    sqlAdminFetcher,
+  }: CloudSQLInstanceOptions) {
+    this.connectionType = connectionType;
+    this.connectionInfo = parseInstanceConnectionName(instanceConnectionName);
+    this.sqlAdminFetcher = sqlAdminFetcher;
+  }
+
+  async init(): Promise<void> {
+    const rsaKeys: RSAKeys = await generateKeys();
+    const metadata: InstanceMetadata =
+      await this.sqlAdminFetcher.getInstanceMetadata(this.connectionInfo);
+    this.ephemeralCert = await this.sqlAdminFetcher.getEphemeralCertificate(
+      this.connectionInfo,
+      rsaKeys.publicKey
+    );
+    this.host = selectIpAddress(metadata.ipAddresses, this.connectionType);
+    this.privateKey = rsaKeys.privateKey;
+    this.serverCaCert = metadata.serverCaCert;
+  }
+}

--- a/src/generate-keys.ts
+++ b/src/generate-keys.ts
@@ -14,7 +14,7 @@
 
 import {promisify} from 'node:util';
 
-interface RSAKeys {
+export interface RSAKeys {
   privateKey: string;
   publicKey: string;
 }

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -19,7 +19,7 @@ import {InstanceConnectionInfo} from './instance-connection-info';
 import {SslCert} from './ssl-cert';
 import {IpAdresses, parseIpAddresses} from './ip-addresses';
 
-interface InstanceMetadata {
+export interface InstanceMetadata {
   ipAddresses: IpAdresses;
   serverCaCert: SslCert;
 }

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -1,0 +1,84 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import {IpAdressesTypes} from '../src/ip-addresses';
+import {CA_CERT, CLIENT_CERT, CLIENT_KEY} from './fixtures/certs';
+import {setupCredentials} from './fixtures/setup-credentials';
+
+t.test('CloudSQLInstance', async t => {
+  setupCredentials(t); // setup google-auth credentials mocks
+
+  const fetcher = {
+    getInstanceMetadata() {
+      return Promise.resolve({
+        ipAddresses: {
+          public: '127.0.0.1',
+        },
+        serverCaCert: {
+          cert: CA_CERT,
+          expirationTime: '2033-01-06T10:00:00.232Z',
+        },
+      });
+    },
+    getEphemeralCertificate() {
+      return Promise.resolve({
+        cert: CLIENT_CERT,
+        expirationTime: '2033-01-06T10:00:00.232Z',
+      });
+    },
+  };
+
+  // mocks generateKeys module so that it can return a deterministic result
+  const {CloudSQLInstance} = t.mock('../src/cloud-sql-instance', {
+    '../src/generate-keys': {
+      generateKeys: async () => ({
+        publicKey: '-----BEGIN PUBLIC KEY-----',
+        privateKey: CLIENT_KEY,
+      }),
+    },
+  });
+
+  const instance = await CloudSQLInstance.getCloudSQLInstance({
+    connectionType: IpAdressesTypes.PUBLIC,
+    instanceConnectionName: 'my-project:us-east1:my-instance',
+    sqlAdminFetcher: fetcher,
+  });
+
+  t.same(
+    instance.ephemeralCert.cert,
+    CLIENT_CERT,
+    'should have expected privateKey'
+  );
+
+  t.same(
+    instance.connectionInfo,
+    {
+      projectId: 'my-project',
+      regionId: 'us-east1',
+      instanceId: 'my-instance',
+    },
+    'should have expected connection info'
+  );
+
+  t.same(instance.privateKey, CLIENT_KEY, 'should have expected privateKey');
+
+  t.same(instance.host, '127.0.0.1', 'should have expected host');
+
+  t.same(
+    instance.serverCaCert.cert,
+    CA_CERT,
+    'should have expected serverCaCert'
+  );
+});


### PR DESCRIPTION
Adds a new `CloudSQLInstance` class that orchestrates the necessary API
calls and holds the resulting values required to open new tls socket
connections.