### PR TITLE
chore: refactor setup tls server

### DIFF
--- a/test/fixtures/setup-tls-server.ts
+++ b/test/fixtures/setup-tls-server.ts
@@ -1,0 +1,39 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {createServer} from 'node:https';
+import {CA_CERT, SERVER_CERT, SERVER_KEY} from './certs';
+
+export async function setupTLSServer(t: Tap.Test): Promise<void> {
+  const server = createServer(
+    {
+      ca: CA_CERT,
+      key: SERVER_KEY,
+      cert: SERVER_CERT,
+      minVersion: 'TLSv1.3',
+    },
+    (req, res) => {
+      res.writeHead(200);
+      res.end('ok');
+    }
+  );
+  await new Promise((res): void => {
+    server.listen(3307, () => {
+      res(null);
+    });
+  });
+  t.teardown(() => {
+    server.close();
+  });
+}

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -12,39 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {createServer} from 'node:https';
 import tls from 'node:tls';
 import t from 'tap';
 import {getSocket, validateCertificate} from '../src/socket';
-import {
-  CA_CERT,
-  CLIENT_CERT,
-  CLIENT_KEY,
-  SERVER_CERT,
-  SERVER_KEY,
-} from './fixtures/certs';
+import {CA_CERT, CLIENT_CERT, CLIENT_KEY} from './fixtures/certs';
+import {setupTLSServer} from './fixtures/setup-tls-server';
 
 t.test('getSocket', async t => {
-  const server = createServer(
-    {
-      ca: CA_CERT,
-      key: SERVER_KEY,
-      cert: SERVER_CERT,
-      minVersion: 'TLSv1.3',
-    },
-    (req, res) => {
-      res.writeHead(200);
-      res.end('ok');
-    }
-  );
-  await new Promise((res): void => {
-    server.listen(3307, () => {
-      res(null);
-    });
-  });
-  t.teardown(() => {
-    server.close();
-  });
+  await setupTLSServer(t);
 
   await new Promise((res, rej): void => {
     const socket = getSocket({


### PR DESCRIPTION
Refactors the tls server setup from `test/setup-tls-server.ts` into a reusable test helper module.