### PR TITLE
chore: refactor property name

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -51,7 +51,7 @@ export class CloudSQLInstance {
   private readonly sqlAdminFetcher: Fetcher;
   private refreshTimeoutID?: ReturnType<typeof setTimeout>;
   private closed = false;
-  public readonly connectionInfo: InstanceConnectionInfo;
+  public readonly instanceInfo: InstanceConnectionInfo;
   public ephemeralCert?: SslCert;
   public host?: string;
   public privateKey?: string;
@@ -63,17 +63,17 @@ export class CloudSQLInstance {
     sqlAdminFetcher,
   }: CloudSQLInstanceOptions) {
     this.connectionType = connectionType;
-    this.connectionInfo = parseInstanceConnectionName(instanceConnectionName);
+    this.instanceInfo = parseInstanceConnectionName(instanceConnectionName);
     this.sqlAdminFetcher = sqlAdminFetcher;
   }
 
   async refresh(): Promise<void> {
     const rsaKeys: RSAKeys = await generateKeys();
     const metadata: InstanceMetadata =
-      await this.sqlAdminFetcher.getInstanceMetadata(this.connectionInfo);
+      await this.sqlAdminFetcher.getInstanceMetadata(this.instanceInfo);
 
     this.ephemeralCert = await this.sqlAdminFetcher.getEphemeralCertificate(
-      this.connectionInfo,
+      this.instanceInfo,
       rsaKeys.publicKey
     );
     this.host = selectIpAddress(metadata.ipAddresses, this.connectionType);

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -143,13 +143,8 @@ export class Connector {
 
     return {
       stream() {
-        const {
-          connectionInfo: instanceInfo,
-          ephemeralCert,
-          host,
-          privateKey,
-          serverCaCert,
-        } = instances.getInstance(instanceConnectionName);
+        const {instanceInfo, ephemeralCert, host, privateKey, serverCaCert} =
+          instances.getInstance(instanceConnectionName);
 
         if (
           instanceInfo &&

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -68,7 +68,7 @@ t.test('CloudSQLInstance', async t => {
   );
 
   t.same(
-    instance.connectionInfo,
+    instance.instanceInfo,
     {
       projectId: 'my-project',
       regionId: 'us-east1',


### PR DESCRIPTION
Renames `CloudSQLInstance` property `connectionInfo` to `instanceInfo` in order to match the same name used in `./src/socket.ts` and elsewhere within the connector.
