### PR TITLE
chore: add cert parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "google-auth-library": "^8.7.0"
       },
       "devDependencies": {
-        "@types/node": "^14.11.2",
+        "@types/node": "^18.14.6",
         "@types/tap": "^15.0.8",
         "c8": "^7.12.0",
         "gts": "^3.1.1",
@@ -787,9 +787,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts": false
   },
   "devDependencies": {
-    "@types/node": "^14.11.2",
+    "@types/node": "^18.14.6",
     "@types/tap": "^15.0.8",
     "c8": "^7.12.0",
     "gts": "^3.1.1",

--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -16,7 +16,8 @@ import {IpAdressesTypes, selectIpAddress} from './ip-addresses';
 import {InstanceConnectionInfo} from './instance-connection-info';
 import {parseInstanceConnectionName} from './parse-instance-connection-name';
 import {InstanceMetadata} from './sqladmin-fetcher';
-import {generateKeys, RSAKeys} from './generate-keys';
+import {generateKeys} from './crypto';
+import {RSAKeys} from './rsa-keys';
 import {SslCert} from './ssl-cert';
 import {getRefreshInterval} from './time';
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,109 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {promisify} from 'node:util';
+import {RSAKeys} from './rsa-keys';
+import {SslCert} from './ssl-cert';
+import {cryptoModule} from './node-crypto';
+
+// The following is a fallback certificate parser for node14 to work around
+// its lack of support to the X509Certificate class parser, this block of code
+// can be safely removed once node14 is no longer supported, along with any
+// `node14ParseCert` call and its unit tests.
+// --- node@14 cert parse fallback start
+import net from 'node:net';
+import tls from 'node:tls';
+
+const node14ParseCert = (cert: string): SslCert => {
+  const isPeerCertificate = (
+    obj: object | tls.PeerCertificate
+  ): obj is tls.PeerCertificate =>
+    (obj as tls.PeerCertificate).valid_to !== undefined;
+
+  let socket;
+  let parsed;
+  try {
+    socket = new tls.TLSSocket(new net.Socket(), {
+      secureContext: tls.createSecureContext({cert}),
+    });
+    parsed = socket.getCertificate();
+  } catch (err) {
+    throw badCertError(err);
+  }
+
+  if (parsed && isPeerCertificate(parsed)) {
+    const expirationTime = parsed.valid_to;
+    socket.destroy();
+    socket = undefined;
+    parsed = undefined;
+
+    return {
+      cert,
+      expirationTime,
+    };
+  }
+  /* c8 ignore next 2 */
+  throw badCertError('Could not read ephemeral certificate.');
+};
+// --- node@14 cert parse fallback end
+
+const badCertError = (err: unknown) =>
+  Object.assign(
+    new Error(`Failed to parse as X.509 certificate: ${String(err)}`),
+    {
+      code: 'EPARSESQLADMINEPH',
+    }
+  );
+
+export async function generateKeys(): Promise<RSAKeys> {
+  const crypto = await cryptoModule();
+  const keygen = promisify(crypto.generateKeyPair);
+
+  const {privateKey, publicKey} = await keygen('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: {
+      type: 'pkcs1',
+      format: 'pem',
+    },
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem',
+    },
+  });
+
+  return {
+    privateKey,
+    publicKey,
+  };
+}
+
+export async function parseCert(cert: string): Promise<SslCert> {
+  const {X509Certificate} = await cryptoModule();
+  if (X509Certificate) {
+    try {
+      const parsed = new X509Certificate(cert);
+      if (parsed && parsed.validTo) {
+        return {
+          cert,
+          expirationTime: parsed.validTo,
+        };
+      }
+
+      throw badCertError('Could not read ephemeral certificate.');
+    } catch (err) {
+      throw badCertError(err);
+    }
+  }
+  return node14ParseCert(cert);
+}

--- a/src/node-crypto.ts
+++ b/src/node-crypto.ts
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {promisify} from 'node:util';
-
-export interface RSAKeys {
-  privateKey: string;
-  publicKey: string;
-}
-
 /* c8 ignore next 4 */
 const noCryptoModuleError = () =>
   Object.assign(new Error('Support to node crypto module is required'), {
     code: 'ENOCRYPTOMODULE',
   });
 
-export async function generateKeys(): Promise<RSAKeys> {
+type Crypto = typeof import('node:crypto');
+export async function cryptoModule(): Promise<Crypto> {
   // check for availability of crypto module and throws an error otherwise
   // ref: https://nodejs.org/dist/latest-v18.x/docs/api/crypto.html#determining-if-crypto-support-is-unavailable
   let crypto;
@@ -35,22 +29,5 @@ export async function generateKeys(): Promise<RSAKeys> {
   } catch (err) {
     throw noCryptoModuleError();
   }
-  const keygen = promisify(crypto.generateKeyPair);
-
-  const {privateKey, publicKey} = await keygen('rsa', {
-    modulusLength: 2048,
-    privateKeyEncoding: {
-      type: 'pkcs1',
-      format: 'pem',
-    },
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem',
-    },
-  });
-
-  return {
-    privateKey,
-    publicKey,
-  };
+  return crypto;
 }

--- a/src/rsa-keys.ts
+++ b/src/rsa-keys.ts
@@ -12,17 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import t from 'tap';
-import {generateKeys} from '../src/generate-keys';
-
-t.test('generateKeys', async t => {
-  const {privateKey, publicKey} = await generateKeys();
-  t.ok(
-    privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----'),
-    'should return a private key string'
-  );
-  t.ok(
-    publicKey.startsWith('-----BEGIN PUBLIC KEY-----'),
-    'should return a public key string'
-  );
-});
+export interface RSAKeys {
+  privateKey: string;
+  publicKey: string;
+}

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -17,6 +17,7 @@ import {sqladmin_v1beta4} from '@googleapis/sqladmin';
 const {Sqladmin} = sqladmin_v1beta4;
 import {InstanceConnectionInfo} from './instance-connection-info';
 import {SslCert} from './ssl-cert';
+import {parseCert} from './crypto';
 import {IpAdresses, parseIpAddresses} from './ip-addresses';
 
 export interface InstanceMetadata {
@@ -135,17 +136,16 @@ export class SQLAdminFetcher {
     }
 
     const {ephemeralCert} = res.data;
-    if (
-      !ephemeralCert ||
-      !ephemeralCert.cert ||
-      !ephemeralCert.expirationTime
-    ) {
+    if (!ephemeralCert || !ephemeralCert.cert) {
       throw noEphemeralCertError();
     }
 
+    // NOTE: If the SQL Admin generateEphemeralCert API starts returning
+    // the expirationTime info, this certificate parsing is no longer needed
+    const {cert, expirationTime} = await parseCert(ephemeralCert.cert);
     return {
-      cert: ephemeralCert.cert,
-      expirationTime: ephemeralCert.expirationTime,
+      cert,
+      expirationTime,
     };
   }
 }

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -42,7 +42,7 @@ t.test('CloudSQLInstance', async t => {
 
   // mocks generateKeys module so that it can return a deterministic result
   const {CloudSQLInstance} = t.mock('../src/cloud-sql-instance', {
-    '../src/generate-keys': {
+    '../src/crypto': {
       generateKeys: async () => ({
         publicKey: '-----BEGIN PUBLIC KEY-----',
         privateKey: CLIENT_KEY,

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -46,7 +46,7 @@ t.test('Connector', async t => {
       },
     },
     '../src/cloud-sql-instance': t.mock('../src/cloud-sql-instance', {
-      '../src/generate-keys': {
+      '../src/crypto': {
         generateKeys: async () => ({
           publicKey: '-----BEGIN PUBLIC KEY-----',
           privateKey: CLIENT_KEY,

--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -1,0 +1,112 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import {CLIENT_CERT} from './fixtures/certs';
+import {parseCert, generateKeys} from '../src/crypto';
+
+t.test('generateKeys', async t => {
+  const {privateKey, publicKey} = await generateKeys();
+  t.ok(
+    privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----'),
+    'should return a private key string'
+  );
+  t.ok(
+    publicKey.startsWith('-----BEGIN PUBLIC KEY-----'),
+    'should return a public key string'
+  );
+});
+
+t.test('parseCert', async t => {
+  const {cert, expirationTime} = await parseCert(CLIENT_CERT);
+  t.same(cert, CLIENT_CERT, 'should return original cert in response');
+  t.same(
+    expirationTime,
+    'Mar 17 02:41:56 2023 GMT',
+    'should return expiration time'
+  );
+});
+
+t.test('parseCert failure', async t => {
+  return t.rejects(
+    parseCert('-----BEGIN PUBLIC KEY-----'),
+    {
+      code: 'EPARSESQLADMINEPH',
+    },
+    'should throw parse ephemeral cert error'
+  );
+});
+
+t.test('parseCert missing expiration time', async t => {
+  const {parseCert} = t.mock('../src/crypto', {
+    '../src/node-crypto': {
+      async cryptoModule() {
+        return {
+          X509Certificate: class {},
+        };
+      },
+    },
+  });
+  return t.rejects(
+    parseCert(CLIENT_CERT),
+    {
+      code: 'EPARSESQLADMINEPH',
+    },
+    'should throw parse ephemeral cert error'
+  );
+});
+
+t.test('parseCert no x509 parser fallback', async t => {
+  const {cryptoModule} = t.mock('../src/node-crypto', {});
+  const {parseCert} = t.mock('../src/crypto', {
+    '../src/node-crypto': {
+      async cryptoModule() {
+        const mod = cryptoModule();
+        return {
+          ...mod,
+          X509Certificate: undefined,
+        };
+      },
+    },
+  });
+  const {cert, expirationTime} = await parseCert(CLIENT_CERT);
+  t.same(cert, CLIENT_CERT, 'should return original cert in response');
+  t.same(
+    expirationTime,
+    'Mar 17 02:41:56 2023 GMT',
+    'should return expiration time'
+  );
+});
+
+t.test('parseCert no x509 parser fallback failure', async t => {
+  const {cryptoModule} = t.mock('../src/node-crypto', {});
+  const {parseCert} = t.mock('../src/crypto', {
+    '../src/node-crypto': {
+      async cryptoModule() {
+        const mod = cryptoModule();
+        return {
+          ...mod,
+          X509Certificate: undefined,
+        };
+      },
+    },
+  });
+  return t.rejects(
+    parseCert('-----BEGIN PUBLIC KEY-----'),
+    {
+      code: 'EPARSESQLADMINEPH',
+    },
+    'should throw parse ephemeral cert error'
+  );
+});

--- a/test/serial/connector-integration.ts
+++ b/test/serial/connector-integration.ts
@@ -70,7 +70,7 @@ t.test('Connector integration test', async t => {
   // mocks generateKeys module so that it can return a deterministic result
   const {Connector} = t.mock('../../src/connector', {
     '../../src/cloud-sql-instance': t.mock('../../src/cloud-sql-instance', {
-      '../../src/generate-keys': {
+      '../../src/crypto': {
         generateKeys: async () => ({
           publicKey: '-----BEGIN PUBLIC KEY-----',
           privateKey: CLIENT_KEY,

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -18,8 +18,9 @@ import {sqladmin_v1beta4} from '@googleapis/sqladmin';
 import {SQLAdminFetcher} from '../src/sqladmin-fetcher';
 import {InstanceConnectionInfo} from '../src/instance-connection-info';
 import {setupCredentials} from './fixtures/setup-credentials';
+import {CLIENT_CERT} from './fixtures/certs';
 
-const certResponse = (instance: string) => ({
+const serverCaCertResponse = (instance: string) => ({
   kind: 'sql#sslCert',
   certSerialNumber: '0',
   cert: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
@@ -31,6 +32,10 @@ const certResponse = (instance: string) => ({
   expirationTime: '2033-01-06T10:00:00.232Z',
 });
 
+const ephCertResponse = {
+  cert: CLIENT_CERT,
+};
+
 const mockRequest = (
   instanceInfo: InstanceConnectionInfo,
   overrides?: sqladmin_v1beta4.Schema$ConnectSettings
@@ -41,7 +46,7 @@ const mockRequest = (
     .get(`/${projectId}/instances/${instanceId}/connectSettings`)
     .reply(200, {
       kind: 'sql#connectSettings',
-      serverCaCert: certResponse(instanceId),
+      serverCaCert: serverCaCertResponse(instanceId),
       ipAddresses: [
         {
           type: 'PRIMARY',
@@ -218,7 +223,7 @@ const mockGenerateEphemeralCertRequest = (
   nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
     .post(`/${projectId}/instances/${instanceId}:generateEphemeralCert`)
     .reply(200, {
-      ephemeralCert: certResponse(instanceId),
+      ephemeralCert: ephCertResponse,
       // overrides any properties from the base mock
       ...overrides,
     });
@@ -241,8 +246,8 @@ t.test('getEphemeralCertificate', async t => {
   t.same(
     ephemeralCert,
     {
-      cert: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
-      expirationTime: '2033-01-06T10:00:00.232Z',
+      cert: CLIENT_CERT,
+      expirationTime: 'Mar 17 02:41:56 2023 GMT',
     },
     'should return expected ssl cert'
   );


### PR DESCRIPTION
Removes previous logic that assumed that responses from SQL Admin `getEphemeralCertificate` would contain an expiration time property.

The ephemeral certificate received from that API response is now parsed in memory in order to extract the expiration time from the parsed value.

Note: The `@types/node` package had to be updated to point to a recent version of the runtime types that contain the X509Certificate parser.
