### PR TITLE
chore: add db options on pg usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
   type: 'PUBLIC'
 });
-const pool = new Pool({ ...clientOpts, max: 5 });
+const pool = new Pool({
+  ...clientOpts,
+  user: 'my-user',
+  password: 'my-password',
+  database: 'db-name',
+  max: 5
+});
 const result = await pool.query('SELECT NOW()');
 
 await pool.end();


### PR DESCRIPTION
Added a more complete example, based on usage from `system-test/pg-connect.cjs`.
