### PR TITLE
chore: add cloud sql connector error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,36 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface CloudSQLConnectorErrorOptions {
+  code: string;
+  errors?: Error[];
+  message: string;
+}
+
+export class CloudSQLConnectorError extends Error {
+  public readonly code: string;
+  public readonly errors: Error[] = [];
+  public readonly message: string;
+  public readonly name = 'CloudSQLConnectorError';
+
+  constructor({code, errors = [], message}: CloudSQLConnectorErrorOptions) {
+    super(message);
+    this.code = code;
+    this.message = message;
+
+    for (const err of errors) {
+      this.errors.push(err);
+    }
+  }
+}

--- a/src/ip-addresses.ts
+++ b/src/ip-addresses.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {sqladmin_v1beta4} from '@googleapis/sqladmin';
+import {CloudSQLConnectorError} from './errors';
 
 export enum IpAdressesTypes {
   PUBLIC = 'PUBLIC',
@@ -24,40 +25,22 @@ export declare interface IpAdresses {
   private?: string;
 }
 
-const noPublicIpAddressError = () =>
-  Object.assign(
-    new Error('Cannot connect to instance, public Ip address not found'),
-    {
-      code: 'ENOPUBLICSQLADMINIPADDRESS',
-    }
-  );
-
-const noPrivateIpAddressError = () =>
-  Object.assign(
-    new Error('Cannot connect to instance, private Ip address not found'),
-    {
-      code: 'ENOPRIVATESQLADMINIPADDRESS',
-    }
-  );
-
-const noIpAddressError = () =>
-  Object.assign(
-    new Error('Cannot connect to instance, it has no supported IP addresses'),
-    {
-      code: 'ENOSQLADMINIPADDRESS',
-    }
-  );
-
 const getPublicIpAddress = (ipAddresses: IpAdresses) => {
   if (!ipAddresses.public) {
-    throw noPublicIpAddressError();
+    throw new CloudSQLConnectorError({
+      message: 'Cannot connect to instance, public Ip address not found',
+      code: 'ENOPUBLICSQLADMINIPADDRESS',
+    });
   }
   return ipAddresses.public;
 };
 
 const getPrivateIpAddress = (ipAddresses: IpAdresses) => {
   if (!ipAddresses.private) {
-    throw noPrivateIpAddressError();
+    throw new CloudSQLConnectorError({
+      message: 'Cannot connect to instance, private Ip address not found',
+      code: 'ENOPRIVATESQLADMINIPADDRESS',
+    });
   }
   return ipAddresses.private;
 };
@@ -66,7 +49,10 @@ export function parseIpAddresses(
   ipResponse: sqladmin_v1beta4.Schema$IpMapping[] | undefined
 ): IpAdresses {
   if (!ipResponse) {
-    throw noIpAddressError();
+    throw new CloudSQLConnectorError({
+      message: 'Cannot connect to instance, it has no supported IP addresses',
+      code: 'ENOSQLADMINIPADDRESS',
+    });
   }
 
   const ipAddresses: IpAdresses = {};
@@ -80,7 +66,10 @@ export function parseIpAddresses(
   }
 
   if (!ipAddresses.public && !ipAddresses.private) {
-    throw noIpAddressError();
+    throw new CloudSQLConnectorError({
+      message: 'Cannot connect to instance, it has no supported IP addresses',
+      code: 'ENOSQLADMINIPADDRESS',
+    });
   }
 
   return ipAddresses;
@@ -96,6 +85,9 @@ export function selectIpAddress(
     case IpAdressesTypes.PRIVATE:
       return getPrivateIpAddress(ipAddresses);
     default:
-      throw noIpAddressError();
+      throw new CloudSQLConnectorError({
+        message: 'Cannot connect to instance, it has no supported IP addresses',
+        code: 'ENOSQLADMINIPADDRESS',
+      });
   }
 }

--- a/src/node-crypto.ts
+++ b/src/node-crypto.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* c8 ignore next 4 */
-const noCryptoModuleError = () =>
-  Object.assign(new Error('Support to node crypto module is required'), {
-    code: 'ENOCRYPTOMODULE',
-  });
+import {CloudSQLConnectorError} from './errors';
 
 type Crypto = typeof import('node:crypto');
 export async function cryptoModule(): Promise<Crypto> {
@@ -25,9 +21,12 @@ export async function cryptoModule(): Promise<Crypto> {
   let crypto;
   try {
     crypto = await import('node:crypto');
-    /* c8 ignore next 3 */
+    /* c8 ignore next 6 */
   } catch (err) {
-    throw noCryptoModuleError();
+    throw new CloudSQLConnectorError({
+      message: 'Support to node crypto module is required',
+      code: 'ENOCRYPTOMODULE',
+    });
   }
   return crypto;
 }

--- a/src/parse-instance-connection-name.ts
+++ b/src/parse-instance-connection-name.ts
@@ -13,43 +13,39 @@
 // limitations under the License.
 
 import {InstanceConnectionInfo} from './instance-connection-info';
-
-const missingInstanceConnectionNameError = () =>
-  Object.assign(
-    new TypeError(
-      'Missing instance connection name, expected: "PROJECT:REGION:INSTANCE"'
-    ),
-    {code: 'ENOCONNECTIONNAME'}
-  );
-
-const malformedInstanceConnnectionNameError = (
-  instanceConnectionName: string
-) =>
-  Object.assign(
-    new TypeError(
-      'Malformed instance connection name provided: expected format ' +
-        `of "PROJECT:REGION:INSTANCE", got ${instanceConnectionName}`
-    ),
-    {code: 'EBADCONNECTIONNAME'}
-  );
+import {CloudSQLConnectorError} from './errors';
 
 export function parseInstanceConnectionName(
   instanceConnectionName: string | undefined
 ): InstanceConnectionInfo {
   if (!instanceConnectionName) {
-    throw missingInstanceConnectionNameError();
+    throw new CloudSQLConnectorError({
+      message:
+        'Missing instance connection name, expected: "PROJECT:REGION:INSTANCE"',
+      code: 'ENOCONNECTIONNAME',
+    });
   }
 
   const connectionNameRegex =
     /(?<projectId>[^:]+(:[^:]+)?):(?<regionId>[^:]+):(?<instanceId>[^:]+)/;
   const matches = String(instanceConnectionName).match(connectionNameRegex);
   if (!matches) {
-    throw malformedInstanceConnnectionNameError(instanceConnectionName);
+    throw new CloudSQLConnectorError({
+      message:
+        'Malformed instance connection name provided: expected format ' +
+        `of "PROJECT:REGION:INSTANCE", got ${instanceConnectionName}`,
+      code: 'EBADCONNECTIONNAME',
+    });
   }
 
   const unmatchedItems = matches[0] !== matches.input;
   if (unmatchedItems || !matches.groups) {
-    throw malformedInstanceConnnectionNameError(instanceConnectionName);
+    throw new CloudSQLConnectorError({
+      message:
+        'Malformed instance connection name provided: expected format ' +
+        `of "PROJECT:REGION:INSTANCE", got ${instanceConnectionName}`,
+      code: 'EBADCONNECTIONNAME',
+    });
   }
 
   return {

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import {CloudSQLConnectorError} from '../src/errors';
+
+const base = new Error('Some error');
+
+const cloudSqlErr = new CloudSQLConnectorError({
+  message: 'An error',
+  code: 'ERR',
+});
+
+try {
+  throw cloudSqlErr;
+} catch (err) {
+  t.ok(
+    (err as Error).stack?.startsWith('CloudSQLConnectorError'),
+    'should have a stack'
+  );
+}
+
+const aggregate = new CloudSQLConnectorError({
+  message: 'Aggregate error',
+  code: 'AGGERR',
+  errors: [base, cloudSqlErr],
+});
+
+try {
+  throw aggregate;
+} catch (err) {
+  t.same(
+    (err as CloudSQLConnectorError).errors,
+    [base, cloudSqlErr],
+    'should have errors'
+  );
+  t.ok(
+    (err as Error).stack?.startsWith('CloudSQLConnectorError: Aggregate error'),
+    'should have a stack'
+  );
+}


### PR DESCRIPTION
Add a custom `CloudSQLConnectorError` class that extends `Error` and acts as an `AggregateError` in order to provide a more robust error handling. Making sure to not forward original errors in the connector.

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
