### PR TITLE
chore: fix build system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "google-auth-library": "^8.7.0"
       },
       "devDependencies": {
+        "@google-cloud/cloud-sql-connector": "file:",
         "@types/node": "^18.14.6",
         "@types/tap": "^15.0.8",
         "c8": "^7.12.0",
@@ -545,6 +546,10 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@googleapis/sqladmin": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "presnap": "npm run prepare",
     "test": "c8 tap",
     "snap": "c8 tap",
+    "presystem-test": "npm run prepare",
     "system-test": "tap --no-coverage system-test",
     "lint": "gts check",
     "fix": "gts fix",
@@ -46,6 +47,7 @@
     "ts": false
   },
   "devDependencies": {
+    "@google-cloud/cloud-sql-connector": "file:",
     "@types/node": "^18.14.6",
     "@types/tap": "^15.0.8",
     "c8": "^7.12.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,5 @@
 import {Connector, ConnectionOptions, DriverOptions} from './connector';
 import {IpAdressesTypes} from './ip-addresses';
 
-export {Connector, ConnectionOptions, DriverOptions};
+export {Connector, type ConnectionOptions, type DriverOptions};
 export {IpAdressesTypes};

--- a/system-test/pg-connect.cjs
+++ b/system-test/pg-connect.cjs
@@ -14,7 +14,7 @@
 
 const t = require('tap');
 const pg = require('pg');
-const {Connector} = require('../dist/cjs/index.js');
+const {Connector} = require('@google-cloud/cloud-sql-connector');
 const {Client} = pg;
 
 t.test('open connection and retrieves standard pg tables', async t => {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -3,6 +3,10 @@
   "exclude": ["./test", "./tap-snapshots"],
   "include": ["src/**/*.ts"],
   "compilerOptions": {
-    "esModuleInterop": true
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig-base.json",
   "exclude": ["./test", "./tap-snapshots"],
   "compilerOptions": {
-    "module": "node16",
+    "module": "esnext",
     "outDir": "dist/mjs"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist/cjs",
-    "moduleResolution": "Node"
+    "outDir": "dist/cjs"
   }
 }


### PR DESCRIPTION
While working on a ESM end-to-end tests I realized the ESM output was not working as expected since https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/6. This PR fixes the build system in order to get the proper ESM output to be exported to `dist/mjs`.
