### PR TITLE
chore: add esm end-to-end connection test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,11 @@ jobs:
         run: npm install
 
       - name: Transpile TypeScript
-        run: npm run compile
+        run: npm run prepare
+
+      - name: Fixup node14 only
+        if: "${{ matrix.node-version == 'v14.x' }}"
+        run: node ./scripts/fixup.cjs
 
       - name: Run Tests
         run: npx c8 tap -c -t0
@@ -137,7 +141,11 @@ jobs:
         run: npm install
 
       - name: Transpile TypeScript
-        run: npm run compile
+        run: npm run prepare
+
+      - name: Fixup node14 only
+        if: "${{ matrix.node-version == 'v14.x' }}"
+        run: node ./scripts/fixup.cjs
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A JavaScript library for connecting securely to your Cloud SQL instances",
   "author": "Google Inc.",
   "main": "./dist/cjs/index.js",
+  "types": "./dist/cjs/index.d.ts",
   "module": "./dist/mjs/index.js",
   "exports": {
     ".": {

--- a/system-test/pg-connect.mjs
+++ b/system-test/pg-connect.mjs
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import pg from 'pg';
+import {Connector} from '@google-cloud/cloud-sql-connector';
+const {Client} = pg;
+
+t.test('open connection and retrieves standard pg tables', async t => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: process.env.POSTGRES_CONNECTION_NAME,
+    type: 'PUBLIC',
+  });
+  const client = new Client({
+    ...clientOpts,
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASS,
+    database: process.env.POSTGRES_DB,
+  });
+  client.connect();
+  const result = await client.query('SELECT * FROM pg_catalog.pg_tables;');
+
+  t.same(result.command, 'SELECT', 'should list correct command in response');
+  t.ok(result.rowCount > 0, 'should be able to retrieve list of tables');
+
+  await client.end();
+  connector.close();
+});


### PR DESCRIPTION
Adds a connect end-to-end test that uses the ESM module system. Depends on https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/31