### PR TITLE
chore: add temporary install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ driver. Currently supported drivers are:
 You can install the library using `npm install`:
 
 ```sh
-npm install @google-cloud/cloud-sql-connector
+npm install GoogleCloudPlatform/cloud-sql-nodejs-connector
 ```
 
 ## Usage


### PR DESCRIPTION
While the library is not yet published to the public npm registry, this should be the preferred method to install it.
