### PR TITLE
chore: update trusted-contribution to not include release-please

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -15,3 +15,5 @@
 annotations:
   - type: label
     text: "tests: run"
+
+trustedContributors: ['renovate-bot', 'gcf-merge-on-green[bot]']


### PR DESCRIPTION
Release-please app is a trusted contributor and thus does not need to have the `tests: run` label added as the builds will already trigger on the PR.