### PR TITLE
fix: publishing build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@
 !/.gitignore
 !/.github
 !/.gitattributes
+!/.trampolinerc
+!/.kokoro
 !/tsconfig*.json

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -16,7 +16,7 @@ build_file: "cloud-sql-nodejs-connector/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:14-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:16-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -21,7 +21,7 @@ build_file: "cloud-sql-nodejs-connector/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:14-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:16-user"
 }
 
 env_vars: {


### PR DESCRIPTION
Switches kokoro build system to use node16 since node14 is still using npm6 which fails to properly build the project since it did not respect the lifecycle scripts when publishing.
