### PR TITLE
fix: esm dist target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,10 +76,6 @@ jobs:
       - name: Transpile TypeScript
         run: npm run prepare
 
-      - name: Fixup node14 only
-        if: "${{ matrix.node-version == 'v14.x' }}"
-        run: node ./scripts/fixup.cjs
-
       - name: Run Tests
         run: npx c8 tap -c -t0
         timeout-minutes: 5
@@ -142,10 +138,6 @@ jobs:
 
       - name: Transpile TypeScript
         run: npm run prepare
-
-      - name: Fixup node14 only
-        if: "${{ matrix.node-version == 'v14.x' }}"
-        run: node ./scripts/fixup.cjs
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "compile": "tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
-    "preprepare": "rm -rf dist",
-    "prepare": "npm run compile",
-    "postprepare": "node ./scripts/fixup.cjs",
+    "prepare": "rm -rf dist && npm run compile && node ./scripts/fixup.cjs",
     "pretest": "npm run prepare",
     "presnap": "npm run prepare",
     "test": "c8 tap",


### PR DESCRIPTION
This changeset fixes a problem in the build system that was failing to properly update module imports to include the `.js` file extension.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/53
