### PR TITLE
ci: remove lint on push trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,6 @@ name: Lint
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   pull_request_target:
     types: [labeled]
 


### PR DESCRIPTION
No need to run lint on push events