### PR TITLE
refactor: change ip type error code

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -70,7 +70,7 @@ class CloudSQLInstanceMap extends Map {
             `getOptions called for instance ${instanceConnectionName} with ipType ${ipType}, ` +
             `but was previously called with ipType ${instance.ipType}. ` +
             'If you require both for your use case, please use a new connector object.',
-          code: 'EBADINSTANCEINFO',
+          code: 'EMISMATCHIPTYPE',
         });
       }
       return;
@@ -102,7 +102,7 @@ class CloudSQLInstanceMap extends Map {
           `getOptions called for instance ${instanceConnectionName} with ipType ${ipType}, ` +
           `but was previously called with ipType ${connectionInstance.ipType}. ` +
           'If you require both for your use case, please use a new connector object.',
-        code: 'EBADINSTANCEINFO',
+        code: 'EMISMATCHIPTYPE',
       });
     }
     return connectionInstance;

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -164,7 +164,9 @@ t.test('Connector bad instance info error', async t => {
     '../src/cloud-sql-instance': {
       CloudSQLInstance: {
         async getCloudSQLInstance() {
-          return {};
+          return {
+            ipType: 'PUBLIC',
+          };
         },
       },
     },


### PR DESCRIPTION
Changed the error code for mismatching ip types in order to avoid it sharing the same error code as a the previously defined invalid instance info error.
