### PR TITLE
chore: add tests for mismatch ip types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "rm -rf dist && npm run compile && node ./scripts/fixup.cjs",
     "pretest": "npm run prepare",
     "presnap": "npm run prepare",
-    "test": "c8 tap",
+    "test": "c8 --100 tap",
     "snap": "c8 tap",
     "presystem-test": "npm run prepare",
     "system-test": "tap --no-coverage system-test",


### PR DESCRIPTION
Add unit tests for mismatching ip types in `test/connector.ts`
