### PR TITLE
chore(ci): Track released artifacts for EO 14028 compliance.

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -31,14 +31,11 @@ npm install
 
 # First, pack this project as a tarball
 
-npm pack .
+TARBALL_BASENAME=$(npm pack)
 
 # Second, publish the tarball that was just created
 
-# npm provides no way to specify, observe, or predict the name of the tarball
-# file it generates.  We have to look in the current directory for the freshest
-# .tgz file.
-TARBALL=$(ls -1 -t *.tgz | head -1)
+TARBALL="$(pwd)/$TARBALL_BASENAME"
 npm publish --access=public --registry=https://wombat-dressing-room.appspot.com "$TARBALL"
 
 # Third, clean up all package-lock.json and *.tgz from the node_modules directory

--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -28,4 +28,24 @@ NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google-cloud-npm-token-1)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install
-npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
+
+# First, pack this project as a tarball
+
+npm pack .
+
+# Second, publish the tarball that was just created
+
+# npm provides no way to specify, observe, or predict the name of the tarball
+# file it generates.  We have to look in the current directory for the freshest
+# .tgz file.
+TARBALL=$(ls -1 -t *.tgz | head -1)
+npm publish --access=public --registry=https://wombat-dressing-room.appspot.com "$TARBALL"
+
+# Third, clean up all package-lock.json and *.tgz from the node_modules directory
+# to simplify artifact reporting.
+
+# Kokoro collects *.tgz and package-lock.json files and stores them in Placer
+# so we can generate SBOMs and attestations.
+# However, we *don't* want Kokoro to collect package-lock.json and *.tgz files
+# that happened to be installed with dependencies.
+find node_modules -name package-lock.json -o -name "*.tgz" | xargs rm -f

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -28,3 +28,15 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/cloud-sql-nodejs-connector/.kokoro/publish.sh"
 }
+
+# Store the packages we uploaded to npmjs.org and their corresponding
+# package-lock.jsons in Placer.  That way, we have a record of exactly
+# what we published, and which version of which tools we used to publish
+# it, which we can use to generate SBOMs and attestations.
+action {
+  define_artifacts {
+    regex: "github/**/*.tgz"
+    regex: "github/**/package-lock.json"
+    strip_prefix: "github"
+  }
+}


### PR DESCRIPTION
## Change Description

The release job will now build the package .tgz and report it to Kokoro using `define_artifacts` so that
Kokoro can generate an SBOM for this artifact.
