### PR TITLE
refactor: auth type should default to password

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ const connector = new Connector();
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
   ipType: 'PUBLIC', 
-  authType: 'PASSWORD'
 });
 const pool = new Pool({
   ...clientOpts,
@@ -110,7 +109,6 @@ const connector = new Connector();
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
   ipType: 'PUBLIC',
-  authType: 'PASSWORD'
 });
 const pool = await mysql.createPool({
   ...clientOpts,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -181,15 +181,7 @@ export class Connector {
       });
     }
 
-    const authType = getAuthType(rawAuthType);
-    if (!authType) {
-      throw new CloudSQLConnectorError({
-        message: `Invalid authentication type: ${String(
-          rawAuthType
-        )}, expected PASSWORD or IAM`,
-        code: 'EBADAUTHTYPE',
-      });
-    }
+    const authType = getAuthType(rawAuthType) || AuthTypes.PASSWORD;
 
     const {instances} = this;
     await instances.loadInstance({

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -59,7 +59,6 @@ t.test('Connector', async t => {
   const connector = new Connector();
   const opts = await connector.getOptions({
     ipType: 'PUBLIC',
-    authType: 'PASSWORD',
     instanceConnectionName: 'my-project:us-east1:my-instance',
   });
   t.same(opts.ssl, false, 'should not use driver ssl options');


### PR DESCRIPTION
Providing a `authType` property should be optional and default to `PASSWORD` instead of throwing an error.
