### PR TITLE
chore: add check for auth types export

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import t from 'tap';
-import {Connector, IpAddressTypes} from '../src/index';
+import {AuthTypes, Connector, IpAddressTypes} from '../src/index';
 
+t.ok(AuthTypes, 'should export AuthTypes enum');
 t.ok(Connector, 'should export Connector constructor');
 t.ok(IpAddressTypes, 'should export IpAddressTypes enum');


### PR DESCRIPTION
Adding a small check for `AuthTypes` export on index file in order to get to 100% unit test coverage.
