### PR TITLE
fix: use proper version for user-agent

### DIFF
--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -22,6 +22,7 @@ import {IpAddresses, parseIpAddresses} from './ip-addresses';
 import {CloudSQLConnectorError} from './errors';
 import {getNearestExpiration} from './time';
 import {AuthTypes} from './auth-types';
+import {version} from '../package.json';
 
 export interface InstanceMetadata {
   ipAddresses: IpAddresses;
@@ -46,7 +47,7 @@ export class SQLAdminFetcher {
       userAgentDirectives: [
         {
           product: 'cloud-sql-nodejs-connector',
-          version: '0.1.0',
+          version: version,
         },
       ],
     });

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "moduleResolution": "node",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Similar to how other Google node libraries are resolving user-agent: [nodejs-auth](https://github.com/googleapis/google-auth-library-nodejs/blob/85f2c9393f64b97290a0698d3ac6754fa9bc951a/src/transporters.ts#LL25C1-L25C1)