### PR TITLE
fix: user-agent version number

### DIFF
--- a/scripts/fixup.cjs
+++ b/scripts/fixup.cjs
@@ -58,9 +58,26 @@ async function fixupImportFileExtensions() {
   }
 }
 
+async function updateVersion() {
+  const versionReplacementFilePaths = [
+    resolve(__dirname, '../dist/cjs/sqladmin-fetcher.js'),
+    resolve(__dirname, '../dist/mjs/sqladmin-fetcher.js')
+  ];
+  const {version} = require('../package.json');
+
+  const replaceVersion = source =>
+    source.replace(/LIBRARY_SEMVER_VERSION/gm, version);
+
+  for (const filepath of versionReplacementFilePaths) {
+    const contents = await readFile(filepath, { encoding: 'utf8' });
+    await writeFile(filepath, replaceVersion(contents));
+  }
+}
+
 async function main() {
   await addModuleSystemTypeFile();
   await fixupImportFileExtensions();
+  await updateVersion();
 }
 
 main();

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -46,7 +46,7 @@ export class SQLAdminFetcher {
       userAgentDirectives: [
         {
           product: 'cloud-sql-nodejs-connector',
-          version: '0.1.0',
+          version: 'LIBRARY_SEMVER_VERSION',
         },
       ],
     });


### PR DESCRIPTION
This changeset fixes the number reported by the library in it's SQL Admin request user-agent header.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/92
