### PR TITLE
refactor: move port value to cloud sql instance

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -59,6 +59,7 @@ export class CloudSQLInstance {
   public readonly instanceInfo: InstanceConnectionInfo;
   public ephemeralCert?: SslCert;
   public host?: string;
+  public port = 3307;
   public privateKey?: string;
   public serverCaCert?: SslCert;
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -193,13 +193,20 @@ export class Connector {
 
     return {
       stream() {
-        const {instanceInfo, ephemeralCert, host, privateKey, serverCaCert} =
-          instances.getInstance({instanceConnectionName, ipType, authType});
+        const {
+          instanceInfo,
+          ephemeralCert,
+          host,
+          port,
+          privateKey,
+          serverCaCert,
+        } = instances.getInstance({instanceConnectionName, ipType, authType});
 
         if (
           instanceInfo &&
           ephemeralCert &&
           host &&
+          port &&
           privateKey &&
           serverCaCert
         ) {
@@ -207,6 +214,7 @@ export class Connector {
             instanceInfo,
             ephemeralCert,
             host,
+            port,
             privateKey,
             serverCaCert,
           });

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -22,6 +22,7 @@ const DEFAULT_KEEP_ALIVE_DELAY_MS = 30 * 1000;
 interface SocketOptions {
   ephemeralCert: SslCert;
   host: string;
+  port: number;
   instanceInfo: InstanceConnectionInfo;
   privateKey: string;
   serverCaCert: SslCert;
@@ -49,13 +50,14 @@ export function validateCertificate(instanceInfo: InstanceConnectionInfo) {
 export function getSocket({
   ephemeralCert,
   host,
+  port,
   instanceInfo,
   privateKey,
   serverCaCert,
 }: SocketOptions): tls.TLSSocket {
   const socketOpts = {
     host,
-    port: 3307,
+    port,
     secureContext: tls.createSecureContext({
       ca: serverCaCert.cert,
       cert: ephemeralCert.cert,

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -82,6 +82,7 @@ t.test('CloudSQLInstance', async t => {
   t.same(instance.privateKey, CLIENT_KEY, 'should have expected privateKey');
 
   t.same(instance.host, '127.0.0.1', 'should have expected host');
+  t.same(instance.port, 3307, 'should have expected port');
 
   t.same(
     instance.serverCaCert.cert,

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -33,6 +33,7 @@ t.test('getSocket', async t => {
         expirationTime: '2033-01-06T10:00:00.232Z',
       },
       host: '127.0.0.1',
+      port: 3307,
       privateKey: CLIENT_KEY,
       serverCaCert: {
         cert: CA_CERT,


### PR DESCRIPTION
Moves the definition of the `port` value to `CloudSQLInstance`, allowing it to be exposed to drivers that might need that value (such as `tedious`) while also making it so that the `port` value is defined in the same place as `host`.

Relates to: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/66
