### PR TITLE
refactor!: remove returned ssl property

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -46,7 +46,6 @@ interface StreamFunction {
 //   instanceConnectionName: 'PROJECT:REGION:INSTANCE',
 // });
 export declare interface DriverOptions {
-  ssl: boolean;
   stream: StreamFunction;
 }
 
@@ -225,7 +224,6 @@ export class Connector {
           code: 'EBADINSTANCEINFO',
         });
       },
-      ssl: false,
     };
   }
 

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -61,7 +61,11 @@ t.test('Connector', async t => {
     ipType: 'PUBLIC',
     instanceConnectionName: 'my-project:us-east1:my-instance',
   });
-  t.same(opts.ssl, false, 'should not use driver ssl options');
+  t.same(
+    typeof opts.stream,
+    'function',
+    'should return expected factory method'
+  );
   connector.close();
 });
 


### PR DESCRIPTION
This changeset removes the property `ssl: false` that was set to the returned object of the `Connector.getOptions()` method.

This should fix type problems when using the connector alongside the `mysql2` in TypeScript, since that defined value is incompatible with the type definitions for that driver.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/116