### PR TITLE
chore: add pg end-to-end tests in typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@google-cloud/cloud-sql-connector",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/sqladmin": "^8.0.0",
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@google-cloud/cloud-sql-connector": "file:",
         "@types/node": "^18.14.6",
+        "@types/pg": "^8.10.1",
         "@types/tap": "^15.0.8",
         "c8": "^7.12.0",
         "gts": "^3.1.1",
@@ -804,6 +805,74 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/pg": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.1.tgz",
+      "integrity": "sha512-AmEHA/XxMxemQom5iDwP62FYNkv+gDDnetRG7v2N2dPtju7UKI7FknUimcZo7SodKTHtckYPzaTqUEvUKbVJEA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
+      "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.0.1",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
+      "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@types/tap": {
       "version": "15.0.8",
@@ -3823,6 +3892,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4082,6 +4157,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
@@ -4242,6 +4326,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
+      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@google-cloud/cloud-sql-connector": "file:",
     "@types/node": "^18.14.6",
+    "@types/pg": "^8.10.1",
     "@types/tap": "^15.0.8",
     "c8": "^7.12.0",
     "gts": "^3.1.1",

--- a/system-test/pg-connect.ts
+++ b/system-test/pg-connect.ts
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+import pg from 'pg';
+import {
+  Connector,
+  AuthTypes,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+const {Client} = pg;
+
+t.test('open connection and retrieves standard pg tables', async t => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: String(process.env.POSTGRES_CONNECTION_NAME),
+    ipType: IpAddressTypes.PUBLIC,
+  });
+  const client = new Client({
+    ...clientOpts,
+    user: String(process.env.POSTGRES_USER),
+    password: String(process.env.POSTGRES_PASS),
+    database: String(process.env.POSTGRES_DB),
+  });
+  client.connect();
+
+  const {
+    rows: [result],
+  } = await client.query('SELECT NOW();');
+  const returnedDate = result['now'];
+  t.ok(returnedDate.getTime(), 'should have valid returned date object');
+
+  await client.end();
+  connector.close();
+});
+
+t.test('open IAM connection and retrieves standard pg tables', async t => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: String(process.env.POSTGRES_IAM_CONNECTION_NAME),
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+  });
+  const client = new Client({
+    ...clientOpts,
+    user: String(process.env.POSTGRES_IAM_USER),
+    database: String(process.env.POSTGRES_DB),
+  });
+  client.connect();
+
+  const {
+    rows: [result],
+  } = await client.query('SELECT NOW();');
+  const returnedDate = result['now'];
+  t.ok(returnedDate.getTime(), 'should have valid returned date object');
+
+  await client.end();
+  connector.close();
+});


### PR DESCRIPTION
This changeset adds TypeScript end-to-end tests to ensure that the final user experience works as intended for TS users.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/118
Depends on: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65527