### PR TITLE
fix: make `ipType` optional and default to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ await pool.end();
 connector.close();
 ```
 
+### Specifying Public or Private IP
+
+The Cloud SQL Connector for Node.js can be used to connect to Cloud SQL instances
+using both public and private IP addresses. Specifying which IP address type to
+connect to can be configured within `getOptions` through the `ipType` argument.
+
+By default, connections will be configured to `'PUBLIC'` anc connect over
+public IP, to configure connections to use an instance's private IP,
+use `'PRIVATE'` for `ipType` as follows:
+
+```js
+const clientOpts = await connector.getOptions({
+  instanceConnectionName: 'my-project:region:my-instance',
+  ipType: 'PRIVATE',
+});
+```
+
 ## Supported Node.js Versions
 
 Our client libraries follow the

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The Cloud SQL Connector for Node.js can be used to connect to Cloud SQL instance
 using both public and private IP addresses. Specifying which IP address type to
 connect to can be configured within `getOptions` through the `ipType` argument.
 
-By default, connections will be configured to `'PUBLIC'` anc connect over
+By default, connections will be configured to `'PUBLIC'` and connect over
 public IP, to configure connections to use an instance's private IP,
 use `'PRIVATE'` for `ipType` as follows:
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -24,7 +24,7 @@ import {CloudSQLConnectorError} from './errors';
 // to the Connector.getOptions method when calling it, e.g:
 // const connector = new Connector()
 // const connectionOptions:ConnectionOptions = {
-//   type: 'PUBLIC',
+//   ipType: 'PUBLIC',
 //   instanceConnectionName: 'PROJECT:REGION:INSTANCE',
 // };
 // await connector.getOptions(connectionOptions);
@@ -42,7 +42,7 @@ interface StreamFunction {
 // the Connector.getOptions method, e.g:
 // const connector = new Connector()
 // const driverOptions:DriverOptions = await connector.getOptions({
-//   type: 'PUBLIC',
+//   ipType: 'PUBLIC',
 //   instanceConnectionName: 'PROJECT:REGION:INSTANCE',
 // });
 export declare interface DriverOptions {
@@ -154,7 +154,7 @@ export class Connector {
   //
   // const connector = new Connector()
   // const opts = await connector.getOptions({
-  //   type: 'PUBLIC',
+  //   ipType: 'PUBLIC',
   //   instanceConnectionName: 'PROJECT:REGION:INSTANCE',
   // });
   // const pool = new Pool(opts)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -164,6 +164,14 @@ export class Connector {
     authType = AuthTypes.PASSWORD,
     instanceConnectionName,
   }: ConnectionOptions): Promise<DriverOptions> {
+    if (!ipType) {
+      throw new CloudSQLConnectorError({
+        message: `Invalid IP type: ${String(
+          ipType
+        )}, expected PUBLIC or PRIVATE`,
+        code: 'EBADCONNIPTYPE',
+      });
+    }
     const {instances} = this;
     await instances.loadInstance({
       ipType,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -164,14 +164,6 @@ export class Connector {
     authType = AuthTypes.PASSWORD,
     instanceConnectionName,
   }: ConnectionOptions): Promise<DriverOptions> {
-    if (!ipType) {
-      throw new CloudSQLConnectorError({
-        message: `Invalid IP type: ${String(
-          ipType
-        )}, expected PUBLIC or PRIVATE`,
-        code: 'EBADCONNIPTYPE',
-      });
-    }
     const {instances} = this;
     await instances.loadInstance({
       ipType,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -29,7 +29,7 @@ import {CloudSQLConnectorError} from './errors';
 // };
 // await connector.getOptions(connectionOptions);
 export declare interface ConnectionOptions {
-  ipType: IpAddressTypes;
+  ipType?: IpAddressTypes;
   authType?: AuthTypes;
   instanceConnectionName: string;
 }
@@ -137,9 +137,6 @@ class CloudSQLInstanceMap extends Map {
   }
 }
 
-const getIpAddressType = (type: IpAddressTypes): IpAddressTypes | undefined =>
-  Object.values(IpAddressTypes).find(x => x === type);
-
 // The Connector class is the main public API to interact
 // with the Cloud SQL Node.js Connector.
 export class Connector {
@@ -163,20 +160,10 @@ export class Connector {
   // const pool = new Pool(opts)
   // const res = await pool.query('SELECT * FROM pg_catalog.pg_tables;')
   async getOptions({
-    ipType: rawIpType,
+    ipType = IpAddressTypes.PUBLIC,
     authType = AuthTypes.PASSWORD,
     instanceConnectionName,
   }: ConnectionOptions): Promise<DriverOptions> {
-    const ipType = getIpAddressType(rawIpType);
-    if (!ipType) {
-      throw new CloudSQLConnectorError({
-        message: `Invalid IP type: ${String(
-          rawIpType
-        )}, expected PUBLIC or PRIVATE`,
-        code: 'EBADCONNIPTYPE',
-      });
-    }
-
     const {instances} = this;
     await instances.loadInstance({
       ipType,

--- a/system-test/mysql2-connect.cjs
+++ b/system-test/mysql2-connect.cjs
@@ -43,7 +43,7 @@ t.test('open IAM connection and run basic mysql commands', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'IAM'
+    authType: 'IAM',
   });
   const conn = await mysql.createConnection({
     ...clientOpts,

--- a/system-test/mysql2-connect.mjs
+++ b/system-test/mysql2-connect.mjs
@@ -21,7 +21,7 @@ t.test('open connection and run basic mysql commands', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.MYSQL_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'PASSWORD'
+    authType: 'PASSWORD',
   });
   const conn = await mysql.createConnection({
     ...clientOpts,

--- a/system-test/mysql2-connect.ts
+++ b/system-test/mysql2-connect.ts
@@ -29,7 +29,6 @@ t.test('open connection and run basic mysql commands', async t => {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName: String(process.env.MYSQL_CONNECTION_NAME),
-    ipType: IpAddressTypes.PUBLIC,
   });
   const conn = await mysql.createConnection({
     ...clientOpts,

--- a/system-test/pg-connect.cjs
+++ b/system-test/pg-connect.cjs
@@ -22,7 +22,7 @@ t.test('open connection and retrieves standard pg tables', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.POSTGRES_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'PASSWORD'
+    authType: 'PASSWORD',
   });
   const client = new Client({
     ...clientOpts,
@@ -47,7 +47,7 @@ t.test('open IAM connection and retrieves standard pg tables', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'IAM'
+    authType: 'IAM',
   });
   const client = new Client({
     ...clientOpts,

--- a/system-test/pg-connect.mjs
+++ b/system-test/pg-connect.mjs
@@ -22,7 +22,7 @@ t.test('open connection and retrieves standard pg tables', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.POSTGRES_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'PASSWORD'
+    authType: 'PASSWORD',
   });
   const client = new Client({
     ...clientOpts,
@@ -47,7 +47,7 @@ t.test('open IAM connection and retrieves standard pg tables', async t => {
   const clientOpts = await connector.getOptions({
     instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
     ipType: 'PUBLIC',
-    authType: 'IAM'
+    authType: 'IAM',
   });
   const client = new Client({
     ...clientOpts,

--- a/system-test/pg-connect.ts
+++ b/system-test/pg-connect.ts
@@ -25,7 +25,6 @@ t.test('open connection and retrieves standard pg tables', async t => {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName: String(process.env.POSTGRES_CONNECTION_NAME),
-    ipType: IpAddressTypes.PUBLIC,
   });
   const client = new Client({
     ...clientOpts,

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -69,24 +69,6 @@ t.test('Connector', async t => {
   connector.close();
 });
 
-t.test('Connector invalid type error', async t => {
-  setupCredentials(t); // setup google-auth credentials mocks
-
-  const connector = new Connector();
-  t.rejects(
-    connector.getOptions({
-      ipType: 'foo' as IpAddressTypes,
-      authType: AuthTypes.PASSWORD,
-      instanceConnectionName: 'my-project:us-east1:my-instance',
-    }),
-    {
-      message: 'Invalid IP type: foo, expected PUBLIC or PRIVATE',
-      code: 'EBADCONNIPTYPE',
-    },
-    'should throw a invalid type error'
-  );
-});
-
 t.test('Connector missing instance info error', async t => {
   setupCredentials(t); // setup google-auth credentials mocks
 


### PR DESCRIPTION
Making `ipType` optional within `getOptions` and default to `'PUBLIC'`

Closes #126 