### PR TITLE
chore: add coverage check ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,87 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Code Coverage
+on:
+  pull_request:
+  pull_request_target:
+    types: [labeled]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  coverage:
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Remove PR Label
+        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!');
+            }
+
+      - name: Checkout base branch
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Setup nodejs
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: "18.x"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Calculate base code coverage
+        run: |
+          export CUR_COVER=$(npx c8 tap | xargs -0 node -p 'parseInt(process.argv[1].split("\nAll files")[1].split("|")[1].trim(), 10)')
+          echo "CUR_COVER=$CUR_COVER" >> $GITHUB_ENV
+
+      - name: Checkout PR branch
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Calculate PR code coverage
+        run: |
+          export PR_COVER=$(npx c8 tap | xargs -0 node -p 'parseInt(process.argv[1].split("\nAll files")[1].split("|")[1].trim(), 10)')
+          echo "PR_COVER=$PR_COVER" >> $GITHUB_ENV
+
+      - name: Verify code coverage. If your reading this and the step has failed, please add tests to cover your changes.
+        run: |
+          echo "BASE BRANCH CODE COVERAGE is ${{ env.CUR_COVER }}%"
+          echo "PULL REQUEST CODE COVERAGE is ${{ env.PR_COVER }}%"
+          if [ "${{ env.PR_COVER }}" -lt "${{ env.CUR_COVER }}"  ]; then
+            exit 1;
+          fi


### PR DESCRIPTION
This changeset introduces a CI check that validates that a new PR never has less coverage than the current code coverage value of the main branch.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/45
