### PR TITLE
ci: force usage of npm version 9 with tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           access_token_lifetime: 600s
 
       - name: Install dependencies
-        run: npm install
+        run: npm install -g npm@9
 
       - name: Transpile TypeScript
         run: npm run prepare
@@ -180,7 +180,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm install -g npm@9
 
       - name: Transpile TypeScript
         run: npm run prepare

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,9 @@ jobs:
           access_token_lifetime: 600s
 
       - name: Install dependencies
-        run: npm install -g npm@9
+        run: |
+          npm install -g npm@9
+          npm install
 
       - name: Transpile TypeScript
         run: npm run prepare
@@ -180,7 +182,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install -g npm@9
+        run: |
+          npm install -g npm@9
+          npm install
 
       - name: Transpile TypeScript
         run: npm run prepare

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           access_token_lifetime: 600s
 
       - name: Install dependencies
-        run: npx npm@9 install
+        run: npx npm@9 install; npx npm@9 install
 
       - name: Transpile TypeScript
         run: npm run prepare
@@ -180,7 +180,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npx npm@9 install
+        run: npx npm@9 install; npx npm@9 install
 
       - name: Transpile TypeScript
         run: npm run prepare

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,9 +90,7 @@ jobs:
           access_token_lifetime: 600s
 
       - name: Install dependencies
-        run: |
-          npm install -g npm@9
-          npm install
+        run: npx npm@9 install
 
       - name: Transpile TypeScript
         run: npm run prepare
@@ -182,9 +180,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: |
-          npm install -g npm@9
-          npm install
+        run: npx npm@9 install
 
       - name: Transpile TypeScript
         run: npm run prepare


### PR DESCRIPTION
node 14.x with windows-latest builds are failing as they can't install `tedious` https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/actions/runs/5204041695/jobs/9406565728