### PR TITLE
chore: add note about connector vs proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@
 [npm-docs]: https://www.npmjs.com/package/@google-cloud/cloud-sql-connector
 
 The **Cloud SQL Node.js Connector** is a Cloud SQL connector designed for use
-with the Node.js runtime. Using a Cloud SQL connector provides the following
-benefits:
+with the Node.js runtime. Using a Cloud SQL connector provides a native
+alternative to the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy)
+while providing the following benefits:
+
 - **IAM Authorization:** uses IAM permissions to control who/what can connect to
 your Cloud SQL instances
 - **Improved Security:** uses robust, updated TLS 1.3 encryption and identity


### PR DESCRIPTION
Adding note that Connector is alternative to Cloud SQL Auth Proxy.

Closes #141 