### PR TITLE
ci: disable windows node 14 builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - platform.os: windows-latest
+          - platform: windows-latest
             node-version: v14.x
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,8 @@ jobs:
             node-version: v14.x
       fail-fast: false
 
-    runs-on: ${{ matrix.platform.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.platform.shell }}
+    runs-on: ${{ matrix.os }}
+
     permissions:
       contents: read
       id-token: write
@@ -139,10 +137,7 @@ jobs:
       issues: write
       pull-requests: write
 
-    runs-on: ${{ matrix.platform.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.platform.shell }}
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Remove PR label

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,17 +128,9 @@ jobs:
     strategy:
       matrix:
         node-version: [v14.x, v16.x, v18.x, v19.x]
-        platform:
-        - os: ubuntu-latest
-          shell: bash
-        - os: macos-latest
-          shell: bash
-        - os: windows-latest
-          shell: powershell
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - platform:
-            - os: windows-latest
-              shell: powershell
+          - os: windows-latest
             node-version: v14.x
       fail-fast: false
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
-            node-version: v14.x
+            node-version: "v14.x"
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - platform.os: windows-latest
+          - platform: windows-latest
             node-version: v14.x
       fail-fast: false
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,9 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - platform: windows-latest
+          - platform:
+            - os: windows-latest
+              shell: powershell
             node-version: v14.x
       fail-fast: false
 
@@ -142,7 +144,9 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - platform: windows-latest
+          - platform:
+            - os: windows-latest
+              shell: powershell
             node-version: v14.x
       fail-fast: false
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,17 +35,9 @@ jobs:
     strategy:
       matrix:
         node-version: [v14.x, v16.x, v18.x, v19.x]
-        platform:
-        - os: ubuntu-latest
-          shell: bash
-        - os: macos-latest
-          shell: bash
-        - os: windows-latest
-          shell: powershell
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - platform:
-            - os: windows-latest
-              shell: powershell
+          - os: windows-latest
             node-version: v14.x
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
-            node-version: v14.x
+            node-version: "v14.x"
       fail-fast: false
     permissions:
       contents: 'read'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - os: windows-latest
+          - platform.os: windows-latest
             node-version: v14.x
       fail-fast: false
 
@@ -142,7 +142,7 @@ jobs:
         - os: windows-latest
           shell: powershell
         exclude:
-          - os: windows-latest
+          - platform.os: windows-latest
             node-version: v14.x
       fail-fast: false
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,9 @@ jobs:
           shell: bash
         - os: windows-latest
           shell: powershell
+        exclude:
+          - os: windows-latest
+            node-version: v14.x
       fail-fast: false
 
     runs-on: ${{ matrix.platform.os }}
@@ -138,6 +141,9 @@ jobs:
           shell: bash
         - os: windows-latest
           shell: powershell
+        exclude:
+          - os: windows-latest
+            node-version: v14.x
       fail-fast: false
     permissions:
       contents: 'read'


### PR DESCRIPTION
Bug with windows node 14 builds are causing CI to fail. Turning off this matrix combination for now.
