### PR TITLE
chore: add package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,18 @@
   "files": [
     "dist"
   ],
+  "keywords": [
+    "connector",
+    "cloud",
+    "cloud-sql",
+    "databases",
+    "db",
+    "Google Cloud",
+    "mysql2",
+    "pg",
+    "sql",
+    "tedious"
+  ],
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
These keywords can be used by search engines when looking up the npm registry and will also render nicely in
https://www.npmjs.com/package/@google-cloud/cloud-sql-connector