### PR TITLE
docs: add sequelize v7 examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 !/package-lock.json
 !/README.md
 !/LICENSE{,.*}
-!/example
+!/examples
 !/scripts
 !/system-test
 !/tap-snapshots

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The connector package is meant to be used alongside a database driver, in the
 following examples you can see how to create a new connector and get valid
 options that can then be used when starting a new connection.
 
+For more examples, check [`examples/`](examples/) folder.
+
 ### Using with PostgreSQL
 
 Here is how to start a new

--- a/examples/sequelize/mysql2.cjs
+++ b/examples/sequelize/mysql2.cjs
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {Sequelize} = require('@sequelize/core');
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+  });
+
+  const database = new Sequelize({
+    dialect: 'mysql',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/mysql2.mjs
+++ b/examples/sequelize/mysql2.mjs
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+  });
+
+  const database = new Sequelize({
+    dialect: 'mysql',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/mysql2.mjs
+++ b/examples/sequelize/mysql2.mjs
@@ -15,28 +15,24 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import {Sequelize} from '@sequelize/core';
 
-const main = async () => {
-  const connector = new Connector();
-  const clientOpts = await connector.getOptions({
-    instanceConnectionName: 'my-project:region:my-instance',
-    ipType: 'PUBLIC',
-    authType: 'IAM',
-  });
+const connector = new Connector();
+const clientOpts = await connector.getOptions({
+  instanceConnectionName: 'my-project:region:my-instance',
+  ipType: 'PUBLIC',
+  authType: 'IAM',
+});
 
-  const database = new Sequelize({
-    dialect: 'mysql',
-    username: 'my-service-account',
-    database: 'my-database',
-    dialectOptions: {
-      ...clientOpts,
-    },
-  });
+const database = new Sequelize({
+  dialect: 'mysql',
+  username: 'my-service-account',
+  database: 'my-database',
+  dialectOptions: {
+    ...clientOpts,
+  },
+});
 
-  await database.authenticate();
-  console.log('Successfully connected to database.');
+await database.authenticate();
+console.log('Successfully connected to database.');
 
-  await database.close();
-  connector.close();
-};
-
-main();
+await database.close();
+connector.close();

--- a/examples/sequelize/mysql2.ts
+++ b/examples/sequelize/mysql2.ts
@@ -1,0 +1,46 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+  });
+
+  const database = new Sequelize({
+    dialect: 'mysql',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/pg.cjs
+++ b/examples/sequelize/pg.cjs
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {Sequelize} = require('@sequelize/core');
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+  });
+
+  const database = new Sequelize({
+    dialect: 'postgres',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/pg.mjs
+++ b/examples/sequelize/pg.mjs
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+  });
+
+  const database = new Sequelize({
+    dialect: 'postgres',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/pg.mjs
+++ b/examples/sequelize/pg.mjs
@@ -15,28 +15,24 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import {Sequelize} from '@sequelize/core';
 
-const main = async () => {
-  const connector = new Connector();
-  const clientOpts = await connector.getOptions({
-    instanceConnectionName: 'my-project:region:my-instance',
-    ipType: 'PUBLIC',
-    authType: 'IAM',
-  });
+const connector = new Connector();
+const clientOpts = await connector.getOptions({
+  instanceConnectionName: 'my-project:region:my-instance',
+  ipType: 'PUBLIC',
+  authType: 'IAM',
+});
 
-  const database = new Sequelize({
-    dialect: 'postgres',
-    username: 'my-service-account',
-    database: 'my-database',
-    dialectOptions: {
-      ...clientOpts,
-    },
-  });
+const database = new Sequelize({
+  dialect: 'postgres',
+  username: 'my-service-account',
+  database: 'my-database',
+  dialectOptions: {
+    ...clientOpts,
+  },
+});
 
-  await database.authenticate();
-  console.log('Successfully connected to database.');
+await database.authenticate();
+console.log('Successfully connected to database.');
 
-  await database.close();
-  connector.close();
-};
-
-main();
+await database.close();
+connector.close();

--- a/examples/sequelize/pg.ts
+++ b/examples/sequelize/pg.ts
@@ -1,0 +1,46 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+  });
+
+  const database = new Sequelize({
+    dialect: 'postgres',
+    username: 'my-service-account',
+    database: 'my-database',
+    dialectOptions: {
+      ...clientOpts,
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/tedious.cjs
+++ b/examples/sequelize/tedious.cjs
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {Sequelize} = require('@sequelize/core');
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getTediousOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'PASSWORD',
+  });
+
+  const database = new Sequelize({
+    dialect: 'mssql',
+    username: 'my-user',
+    password: 'my-password',
+    database: 'my-database',
+    dialectOptions: {
+      options: {
+        ...clientOpts,
+      },
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/tedious.mjs
+++ b/examples/sequelize/tedious.mjs
@@ -15,31 +15,27 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import {Sequelize} from '@sequelize/core';
 
-const main = async () => {
-  const connector = new Connector();
-  const clientOpts = await connector.getTediousOptions({
-    instanceConnectionName: 'my-project:region:my-instance',
-    ipType: 'PUBLIC',
-    authType: 'PASSWORD',
-  });
+const connector = new Connector();
+const clientOpts = await connector.getTediousOptions({
+  instanceConnectionName: 'my-project:region:my-instance',
+  ipType: 'PUBLIC',
+  authType: 'PASSWORD',
+});
 
-  const database = new Sequelize({
-    dialect: 'mssql',
-    username: 'my-user',
-    password: 'my-password',
-    database: 'my-database',
-    dialectOptions: {
-      options: {
-        ...clientOpts,
-      },
+const database = new Sequelize({
+  dialect: 'mssql',
+  username: 'my-user',
+  password: 'my-password',
+  database: 'my-database',
+  dialectOptions: {
+    options: {
+      ...clientOpts,
     },
-  });
+  },
+});
 
-  await database.authenticate();
-  console.log('Successfully connected to database.');
+await database.authenticate();
+console.log('Successfully connected to database.');
 
-  await database.close();
-  connector.close();
-};
-
-main();
+await database.close();
+connector.close();

--- a/examples/sequelize/tedious.mjs
+++ b/examples/sequelize/tedious.mjs
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getTediousOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: 'PUBLIC',
+    authType: 'PASSWORD',
+  });
+
+  const database = new Sequelize({
+    dialect: 'mssql',
+    username: 'my-user',
+    password: 'my-password',
+    database: 'my-database',
+    dialectOptions: {
+      options: {
+        ...clientOpts,
+      },
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();

--- a/examples/sequelize/tedious.ts
+++ b/examples/sequelize/tedious.ts
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {Sequelize} from '@sequelize/core';
+
+const main = async () => {
+  const connector = new Connector();
+  const clientOpts = await connector.getTediousOptions({
+    instanceConnectionName: 'my-project:region:my-instance',
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.PASSWORD,
+  });
+
+  const database = new Sequelize({
+    dialect: 'mssql',
+    username: 'my-user',
+    password: 'my-password',
+    database: 'my-database',
+    dialectOptions: {
+      options: {
+        ...clientOpts,
+      },
+    },
+  });
+
+  await database.authenticate();
+  console.log('Successfully connected to database.');
+
+  await database.close();
+  connector.close();
+};
+
+main();


### PR DESCRIPTION
## Change Description

Adds examples of using `cloud-sql-nodejs-connector` library with [`sequelize 7`](https://sequelize.org) for `pg`, `mysql2`, and `tedious` drivers.

## Checklist

- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #110
