### PR TITLE
chore: refactor cloud sql instance refresh

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -54,8 +54,7 @@ export class CloudSQLInstance {
   private readonly ipType: IpAddressTypes;
   private readonly authType: AuthTypes;
   private readonly sqlAdminFetcher: Fetcher;
-  private refreshTimeoutID?: ReturnType<typeof setTimeout>;
-  private closed = false;
+  private scheduledRefreshID?: ReturnType<typeof setTimeout>;
   public readonly instanceInfo: InstanceConnectionInfo;
   public ephemeralCert?: SslCert;
   public host?: string;
@@ -89,17 +88,14 @@ export class CloudSQLInstance {
     this.privateKey = rsaKeys.privateKey;
     this.serverCaCert = metadata.serverCaCert;
 
-    if (!this.closed) {
-      this.refreshTimeoutID = setTimeout(() => {
-        this.refresh();
-      }, getRefreshInterval(this.ephemeralCert.expirationTime));
-    }
+    this.scheduledRefreshID = setTimeout(() => {
+      this.refresh();
+    }, getRefreshInterval(this.ephemeralCert.expirationTime));
   }
 
-  close(): void {
-    if (this.refreshTimeoutID) {
-      clearTimeout(this.refreshTimeoutID);
+  cancelRefresh(): void {
+    if (this.scheduledRefreshID) {
+      clearTimeout(this.scheduledRefreshID);
     }
-    this.closed = true;
   }
 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -248,7 +248,7 @@ export class Connector {
   // instances timeout callbacks that refresh instance info
   close(): void {
     for (const instance of this.instances.values()) {
-      instance.close();
+      instance.cancelRefresh();
     }
   }
 }

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -90,7 +90,7 @@ t.test('CloudSQLInstance', async t => {
     'should have expected serverCaCert'
   );
 
-  instance.close();
+  instance.cancelRefresh();
 
   await new Promise(res => {
     const start = Date.now();
@@ -104,7 +104,7 @@ t.test('CloudSQLInstance', async t => {
     refreshInstance._refresh = refreshInstance.refresh;
     refreshInstance.refresh = () => {
       if (refreshCount === 3) {
-        refreshInstance.close();
+        refreshInstance.cancelRefresh();
         const end = Date.now();
         const duration = end - start;
         t.ok(


### PR DESCRIPTION
This changeset removes the unnecessary flag `closed` from the CloudSQLInstance class and renames `close` -> `cancelRefresh` for clarity.

Refs: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/195