### PR TITLE
chore: refactor tsconfig to support esm deps

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -6,7 +6,6 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "moduleResolution": "node",
     "skipLibCheck": true
   }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -3,6 +3,7 @@
   "exclude": ["./test", "./tap-snapshots"],
   "compilerOptions": {
     "module": "esnext",
+    "moduleResolution": "node",
     "outDir": "dist/mjs"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "dist/cjs"
   }
 }


### PR DESCRIPTION
Adjusting the tsconfig values to allow for usage of an esm-only dependency.

For reference, this is the only meaningful difference in `dist` output, due to **tsc** no longer transpiling dynamic import expressions in CommonJS output (supported since node13):

```patch
diff --git a/dist/cjs/node-crypto.js b/dist/cjs/node-crypto.js
index v0.5.1..v0.5.2-dev 100644
--- a/dist/cjs/node-crypto.js
+++ b/dist/cjs/node-crypto.js
@@ -12,29 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.cryptoModule = void 0;
 const errors_1 = require("./errors");
@@ -43,7 +20,7 @@
     // ref: https://nodejs.org/dist/latest-v18.x/docs/api/crypto.html#determining-if-crypto-support-is-unavailable
     let crypto;
     try {
-        crypto = await Promise.resolve().then(() => __importStar(require('node:crypto')));
+        crypto = await import('node:crypto');
         /* c8 ignore next 6 */
     }
     catch (err) {
```

More info on the config values:
- https://www.typescriptlang.org/tsconfig#module
- https://www.typescriptlang.org/tsconfig#moduleResolution

Refs: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/195
