### PR TITLE
feat: support custom SQL Admin API endpoint

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -147,7 +147,7 @@ class CloudSQLInstanceMap extends Map {
 }
 
 interface ConnectorOptions {
-  sqlAdminRootUrl?: string;
+  sqlAdminAPIEndpoint?: string;
 }
 
 // The Connector class is the main public API to interact
@@ -156,9 +156,9 @@ export class Connector {
   private readonly instances: CloudSQLInstanceMap;
   private readonly sqlAdminFetcher: SQLAdminFetcher;
 
-  constructor({sqlAdminRootUrl}: ConnectorOptions = {}) {
+  constructor({sqlAdminAPIEndpoint}: ConnectorOptions = {}) {
     this.instances = new CloudSQLInstanceMap();
-    this.sqlAdminFetcher = new SQLAdminFetcher({sqlAdminRootUrl});
+    this.sqlAdminFetcher = new SQLAdminFetcher({sqlAdminAPIEndpoint});
   }
 
   // Connector.getOptions is a method that accepts a Cloud SQL instance

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -152,9 +152,9 @@ export class Connector {
   private readonly instances: CloudSQLInstanceMap;
   private readonly sqlAdminFetcher: SQLAdminFetcher;
 
-  constructor() {
+  constructor(options?: {sqlAdminRootUrl?: string}) {
     this.instances = new CloudSQLInstanceMap();
-    this.sqlAdminFetcher = new SQLAdminFetcher();
+    this.sqlAdminFetcher = new SQLAdminFetcher(options);
   }
 
   // Connector.getOptions is a method that accepts a Cloud SQL instance

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -146,15 +146,19 @@ class CloudSQLInstanceMap extends Map {
   }
 }
 
+interface ConnectorOptions {
+  sqlAdminRootUrl?: string;
+}
+
 // The Connector class is the main public API to interact
 // with the Cloud SQL Node.js Connector.
 export class Connector {
   private readonly instances: CloudSQLInstanceMap;
   private readonly sqlAdminFetcher: SQLAdminFetcher;
 
-  constructor(options?: {sqlAdminRootUrl?: string}) {
+  constructor({sqlAdminRootUrl}: ConnectorOptions = {}) {
     this.instances = new CloudSQLInstanceMap();
-    this.sqlAdminFetcher = new SQLAdminFetcher(options);
+    this.sqlAdminFetcher = new SQLAdminFetcher({sqlAdminRootUrl});
   }
 
   // Connector.getOptions is a method that accepts a Cloud SQL instance

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -72,11 +72,12 @@ export class SQLAdminFetcher {
   private readonly client: sqladmin_v1beta4.Sqladmin;
   private readonly auth: GoogleAuth;
 
-  constructor(loginAuth?: GoogleAuth) {
+  constructor(options?: {loginAuth?: GoogleAuth; sqlAdminRootUrl?: string}) {
     const auth = new GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
     });
     this.client = new Sqladmin({
+      rootUrl: options?.sqlAdminRootUrl,
       auth,
       userAgentDirectives: [
         {
@@ -87,7 +88,7 @@ export class SQLAdminFetcher {
     });
 
     this.auth =
-      loginAuth ||
+      options?.loginAuth ||
       new GoogleAuth({
         scopes: ['https://www.googleapis.com/auth/sqlservice.login'],
       });

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -68,16 +68,21 @@ function cleanGaxiosConfig() {
   gaxios.defaults = defaultGaxiosConfig;
 }
 
+interface SQLAdminFetcherOptions {
+  loginAuth?: GoogleAuth;
+  sqlAdminRootUrl?: string;
+}
+
 export class SQLAdminFetcher {
   private readonly client: sqladmin_v1beta4.Sqladmin;
   private readonly auth: GoogleAuth;
 
-  constructor(options?: {loginAuth?: GoogleAuth; sqlAdminRootUrl?: string}) {
+  constructor({loginAuth, sqlAdminRootUrl}: SQLAdminFetcherOptions = {}) {
     const auth = new GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
     });
     this.client = new Sqladmin({
-      rootUrl: options?.sqlAdminRootUrl,
+      rootUrl: sqlAdminRootUrl,
       auth,
       userAgentDirectives: [
         {
@@ -88,7 +93,7 @@ export class SQLAdminFetcher {
     });
 
     this.auth =
-      options?.loginAuth ||
+      loginAuth ||
       new GoogleAuth({
         scopes: ['https://www.googleapis.com/auth/sqlservice.login'],
       });

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -70,19 +70,19 @@ function cleanGaxiosConfig() {
 
 export interface SQLAdminFetcherOptions {
   loginAuth?: GoogleAuth;
-  sqlAdminRootUrl?: string;
+  sqlAdminAPIEndpoint?: string;
 }
 
 export class SQLAdminFetcher {
   private readonly client: sqladmin_v1beta4.Sqladmin;
   private readonly auth: GoogleAuth;
 
-  constructor({loginAuth, sqlAdminRootUrl}: SQLAdminFetcherOptions = {}) {
+  constructor({loginAuth, sqlAdminAPIEndpoint}: SQLAdminFetcherOptions = {}) {
     const auth = new GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
     });
     this.client = new Sqladmin({
-      rootUrl: sqlAdminRootUrl,
+      rootUrl: sqlAdminAPIEndpoint,
       auth,
       userAgentDirectives: [
         {

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -68,7 +68,7 @@ function cleanGaxiosConfig() {
   gaxios.defaults = defaultGaxiosConfig;
 }
 
-interface SQLAdminFetcherOptions {
+export interface SQLAdminFetcherOptions {
   loginAuth?: GoogleAuth;
   sqlAdminRootUrl?: string;
 }

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -18,6 +18,7 @@ import {setupCredentials} from './fixtures/setup-credentials';
 import {IpAddressTypes} from '../src/ip-addresses';
 import {CA_CERT, CLIENT_CERT, CLIENT_KEY} from './fixtures/certs';
 import {AuthTypes} from '../src/auth-types';
+import {SQLAdminFetcherOptions} from '../src/sqladmin-fetcher';
 
 t.test('Connector', async t => {
   setupCredentials(t); // setup google-auth credentials mocks
@@ -551,4 +552,24 @@ t.test('Connector using IAM with Tedious driver', async t => {
     },
     'should throw a missing iam support error'
   );
+});
+
+t.test('Connector, custom sqlAdminRootUrl', async t => {
+  const expectedSqlAdminRootUrl = 'https://sqladmin.mydomain.com';
+  let actualSqlAdminRootUrl: string | undefined;
+  // mocks sql admin fetcher to check that the custom
+  // sqlAdminRootUrl is correctly passed into it
+  const {Connector} = t.mock('../src/connector', {
+    '../src/sqladmin-fetcher': {
+      SQLAdminFetcher: class {
+        constructor({sqlAdminRootUrl}: SQLAdminFetcherOptions) {
+          actualSqlAdminRootUrl = sqlAdminRootUrl;
+        }
+      },
+    },
+  });
+
+  new Connector({sqlAdminRootUrl: expectedSqlAdminRootUrl});
+
+  t.same(actualSqlAdminRootUrl, expectedSqlAdminRootUrl);
 });

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -627,22 +627,22 @@ t.test('Connector force refresh on socket connection error', async t => {
   connector.close();
 });
 
-t.test('Connector, custom sqlAdminRootUrl', async t => {
-  const expectedSqlAdminRootUrl = 'https://sqladmin.mydomain.com';
-  let actualSqlAdminRootUrl: string | undefined;
+t.test('Connector, custom sqlAdminAPIEndpoint', async t => {
+  const expectedsqlAdminAPIEndpoint = 'https://sqladmin.mydomain.com';
+  let actualsqlAdminAPIEndpoint: string | undefined;
   // mocks sql admin fetcher to check that the custom
-  // sqlAdminRootUrl is correctly passed into it
+  // sqlAdminAPIEndpoint is correctly passed into it
   const {Connector} = t.mock('../src/connector', {
     '../src/sqladmin-fetcher': {
       SQLAdminFetcher: class {
-        constructor({sqlAdminRootUrl}: SQLAdminFetcherOptions) {
-          actualSqlAdminRootUrl = sqlAdminRootUrl;
+        constructor({sqlAdminAPIEndpoint}: SQLAdminFetcherOptions) {
+          actualsqlAdminAPIEndpoint = sqlAdminAPIEndpoint;
         }
       },
     },
   });
 
-  new Connector({sqlAdminRootUrl: expectedSqlAdminRootUrl});
+  new Connector({sqlAdminAPIEndpoint: expectedsqlAdminAPIEndpoint});
 
-  t.same(actualSqlAdminRootUrl, expectedSqlAdminRootUrl);
+  t.same(actualsqlAdminAPIEndpoint, expectedsqlAdminAPIEndpoint);
 });

--- a/test/serial/connector-integration.ts
+++ b/test/serial/connector-integration.ts
@@ -18,85 +18,106 @@ import {CA_CERT, CLIENT_CERT, CLIENT_KEY} from '../fixtures/certs';
 import {setupCredentials} from '../fixtures/setup-credentials';
 import {setupTLSServer} from '../fixtures/setup-tls-server';
 
-// test that reaches out for both Google Auth & SQL Admin APIs,
-// then use retrieved keys and certs to stablish an actual
-// socket connection to a mock TLS server
-t.test('Connector integration test', async t => {
-  setupCredentials(t); // setup google-auth credentials mocks
-  await setupTLSServer(t);
+const testCases = [
+  {
+    description: 'default SQL Admin API endpoint',
+    connectorOptions: {},
+    sqlAdminRootUrl: 'https://sqladmin.googleapis.com',
+  },
+  {
+    description: 'custom SQL Admin API endpoint',
+    connectorOptions: {
+      sqlAdminRootUrl: 'https://sqladmin.mydomain.com',
+    },
+    sqlAdminRootUrl: 'https://sqladmin.mydomain.com',
+  },
+];
 
-  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
-    .get('/my-project/instances/my-instance/connectSettings')
-    .reply(200, {
-      kind: 'sql#connectSettings',
-      serverCaCert: {
-        kind: 'sql#sslCert',
-        certSerialNumber: '0',
-        cert: CA_CERT,
-        commonName:
-          'C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=1234',
-        sha1Fingerprint: '004fe8623f02cb953bb5addbd0309f3b8f136c00',
-        instance: 'my-instance',
-        createTime: '2023-01-01T10:00:00.232Z',
-        expirationTime: '2033-01-06T10:00:00.232Z',
-      },
-      ipAddresses: [
-        {
-          type: 'PRIMARY',
-          ipAddress: '127.0.0.1',
+testCases.forEach(({description, connectorOptions, sqlAdminRootUrl}) => {
+  // test that reaches out for both Google Auth & SQL Admin APIs,
+  // then use retrieved keys and certs to stablish an actual
+  // socket connection to a mock TLS server
+  t.test(`Connector integration test ${description}`, async t => {
+    setupCredentials(t); // setup google-auth credentials mocks
+    await setupTLSServer(t);
+
+    nock(sqlAdminRootUrl)
+      .get(
+        '/sql/v1beta4/projects/my-project/instances/my-instance/connectSettings'
+      )
+      .reply(200, {
+        kind: 'sql#connectSettings',
+        serverCaCert: {
+          kind: 'sql#sslCert',
+          certSerialNumber: '0',
+          cert: CA_CERT,
+          commonName:
+            'C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=1234',
+          sha1Fingerprint: '004fe8623f02cb953bb5addbd0309f3b8f136c00',
+          instance: 'my-instance',
+          createTime: '2023-01-01T10:00:00.232Z',
+          expirationTime: '2033-01-06T10:00:00.232Z',
         },
-      ],
-      region: 'us-east1',
-      databaseVersion: 'POSTGRES_14',
-      backendType: 'SECOND_GEN',
+        ipAddresses: [
+          {
+            type: 'PRIMARY',
+            ipAddress: '127.0.0.1',
+          },
+        ],
+        region: 'us-east1',
+        databaseVersion: 'POSTGRES_14',
+        backendType: 'SECOND_GEN',
+      });
+
+    nock(sqlAdminRootUrl)
+      .post(
+        '/sql/v1beta4/projects/my-project/instances/my-instance:generateEphemeralCert'
+      )
+      .reply(200, {
+        ephemeralCert: {
+          kind: 'sql#sslCert',
+          certSerialNumber: '0',
+          cert: CLIENT_CERT,
+          commonName:
+            'C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=1234',
+          sha1Fingerprint: '004fe8623f02cb953bb5addbd0309f3b8f136c00',
+          instance: 'my-instance',
+          createTime: '2023-01-01T10:00:00.232Z',
+          expirationTime: '2033-01-06T10:00:00.232Z',
+        },
+      });
+
+    // mocks generateKeys module so that it can return a deterministic result
+    const {Connector} = t.mock('../../src/connector', {
+      '../../src/cloud-sql-instance': t.mock('../../src/cloud-sql-instance', {
+        '../../src/crypto': {
+          generateKeys: async () => ({
+            publicKey: '-----BEGIN PUBLIC KEY-----',
+            privateKey: CLIENT_KEY,
+          }),
+        },
+      }),
     });
 
-  nock('https://sqladmin.googleapis.com/sql/v1beta4/projects')
-    .post('/my-project/instances/my-instance:generateEphemeralCert')
-    .reply(200, {
-      ephemeralCert: {
-        kind: 'sql#sslCert',
-        certSerialNumber: '0',
-        cert: CLIENT_CERT,
-        commonName:
-          'C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=1234',
-        sha1Fingerprint: '004fe8623f02cb953bb5addbd0309f3b8f136c00',
-        instance: 'my-instance',
-        createTime: '2023-01-01T10:00:00.232Z',
-        expirationTime: '2033-01-06T10:00:00.232Z',
-      },
+    const connector = new Connector(connectorOptions);
+    const opts = await connector.getOptions({
+      ipType: 'PUBLIC',
+      authType: 'PASSWORD',
+      instanceConnectionName: 'my-project:us-east1:my-instance',
     });
 
-  // mocks generateKeys module so that it can return a deterministic result
-  const {Connector} = t.mock('../../src/connector', {
-    '../../src/cloud-sql-instance': t.mock('../../src/cloud-sql-instance', {
-      '../../src/crypto': {
-        generateKeys: async () => ({
-          publicKey: '-----BEGIN PUBLIC KEY-----',
-          privateKey: CLIENT_KEY,
-        }),
-      },
-    }),
-  });
-
-  const connector = new Connector();
-  const opts = await connector.getOptions({
-    ipType: 'PUBLIC',
-    authType: 'PASSWORD',
-    instanceConnectionName: 'my-project:us-east1:my-instance',
-  });
-
-  await new Promise((res, rej): void => {
-    // driver factory method to retrieve a new socket
-    const tlsSocket = opts.stream();
-    tlsSocket.on('secureConnect', () => {
-      t.ok(tlsSocket.authorized, 'socket connected');
-      tlsSocket.end();
-      connector.close();
-      res(null);
-    });
-    tlsSocket.on('error', (err: Error) => {
-      rej(err);
+    await new Promise((res, rej): void => {
+      // driver factory method to retrieve a new socket
+      const tlsSocket = opts.stream();
+      tlsSocket.on('secureConnect', () => {
+        t.ok(tlsSocket.authorized, 'socket connected');
+        tlsSocket.end();
+        connector.close();
+        res(null);
+      });
+      tlsSocket.on('error', (err: Error) => {
+        rej(err);
+      });
     });
   });
 });

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -42,11 +42,11 @@ const ephCertResponse = {
 const mockRequest = (
   instanceInfo: InstanceConnectionInfo,
   overrides?: sqladmin_v1beta4.Schema$ConnectSettings,
-  sqlAdminRootUrl?: string
+  sqlAdminAPIEndpoint?: string
 ): void => {
   const {projectId, regionId, instanceId} = instanceInfo;
 
-  nock(sqlAdminRootUrl ?? 'https://sqladmin.googleapis.com')
+  nock(sqlAdminAPIEndpoint ?? 'https://sqladmin.googleapis.com')
     .get(
       `/sql/v1beta4/projects/${projectId}/instances/${instanceId}/connectSettings`
     )
@@ -101,15 +101,15 @@ t.test('getInstanceMetadata', async t => {
 
 t.test('getInstanceMetadata custom SQL Admin API endpoint', async t => {
   setupCredentials(t);
-  const sqlAdminRootUrl = 'https://sqladmin.mydomain.com';
+  const sqlAdminAPIEndpoint = 'https://sqladmin.mydomain.com';
   const instanceConnectionInfo: InstanceConnectionInfo = {
     projectId: 'my-project',
     regionId: 'us-east1',
     instanceId: 'my-instance',
   };
-  mockRequest(instanceConnectionInfo, {}, sqlAdminRootUrl);
+  mockRequest(instanceConnectionInfo, {}, sqlAdminAPIEndpoint);
 
-  const fetcher = new SQLAdminFetcher({sqlAdminRootUrl});
+  const fetcher = new SQLAdminFetcher({sqlAdminAPIEndpoint});
   const instanceMetadata = await fetcher.getInstanceMetadata(
     instanceConnectionInfo
   );
@@ -252,11 +252,11 @@ t.test('getInstanceMetadata invalid region', async t => {
 const mockGenerateEphemeralCertRequest = (
   instanceInfo: InstanceConnectionInfo,
   overrides?: sqladmin_v1beta4.Schema$GenerateEphemeralCertResponse,
-  sqlAdminRootUrl?: string
+  sqlAdminAPIEndpoint?: string
 ): void => {
   const {projectId, instanceId} = instanceInfo;
 
-  nock(sqlAdminRootUrl ?? 'https://sqladmin.googleapis.com')
+  nock(sqlAdminAPIEndpoint ?? 'https://sqladmin.googleapis.com')
     .post(
       `/sql/v1beta4/projects/${projectId}/instances/${instanceId}:generateEphemeralCert`
     )
@@ -294,15 +294,19 @@ t.test('getEphemeralCertificate', async t => {
 
 t.test('getEphemeralCertificate custom SQL Admin API endpoint', async t => {
   setupCredentials(t);
-  const sqlAdminRootUrl = 'https://sqladmin.mydomain.com';
+  const sqlAdminAPIEndpoint = 'https://sqladmin.mydomain.com';
   const instanceConnectionInfo: InstanceConnectionInfo = {
     projectId: 'my-project',
     regionId: 'us-east1',
     instanceId: 'my-instance',
   };
-  mockGenerateEphemeralCertRequest(instanceConnectionInfo, {}, sqlAdminRootUrl);
+  mockGenerateEphemeralCertRequest(
+    instanceConnectionInfo,
+    {},
+    sqlAdminAPIEndpoint
+  );
 
-  const fetcher = new SQLAdminFetcher({sqlAdminRootUrl});
+  const fetcher = new SQLAdminFetcher({sqlAdminAPIEndpoint});
   const ephemeralCert = await fetcher.getEphemeralCertificate(
     instanceConnectionInfo,
     'key',


### PR DESCRIPTION
Allows library users to optionally pass custom
SQL Admin API endpoint in the Connector constructor.

Fixes: #64
