### PR TITLE
fix: add .js ext. for mjs imports in .d.ts files

### DIFF
--- a/scripts/fixup.cjs
+++ b/scripts/fixup.cjs
@@ -45,7 +45,7 @@ async function fixupImportFileExtensions() {
       const path = resolve(mjsDistFolder, entry.name);
       if (entry.isDirectory()) {
         recursiveReadDir(path);
-      } else if (path.endsWith('.js')) {
+      } else if (path.endsWith('.js') || path.endsWith('.d.ts')) {
         mjsFilePaths.push(path);
       }
     }


### PR DESCRIPTION
## Change Description

Updates `fixup` script to append `.js` extension for imports in `dist/mjs/**/*.d.ts` files, too.

From [Typescript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions):

> relative import paths need full extensions (e.g we have to write import "./foo.js" instead of import "./foo")

## Checklist

- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea.

## Relevant issues:

- Fixes: #214
