### PR TITLE
fix: silent refresh errors on active connection

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -217,7 +217,7 @@ export class Connector {
             await cloudSqlInstance.forceRefresh();
           });
           tlsSocket.once('secureConnect', async () => {
-            cloudSqlInstance.setStablishedConnection();
+            cloudSqlInstance.setEstablishedConnection();
           });
           return tlsSocket;
         }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -216,6 +216,9 @@ export class Connector {
           tlsSocket.once('error', async () => {
             await cloudSqlInstance.forceRefresh();
           });
+          tlsSocket.once('secureConnect', async () => {
+            cloudSqlInstance.setActiveConnection();
+          });
           return tlsSocket;
         }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -217,7 +217,7 @@ export class Connector {
             await cloudSqlInstance.forceRefresh();
           });
           tlsSocket.once('secureConnect', async () => {
-            cloudSqlInstance.setActiveConnection();
+            cloudSqlInstance.setStablishedConnection();
           });
           return tlsSocket;
         }

--- a/src/time.ts
+++ b/src/time.ts
@@ -43,3 +43,8 @@ export function getNearestExpiration(
   }
   return new Date(certExp).toISOString();
 }
+
+export function isExpirationTimeValid(isoTime: string): boolean {
+  const expirationTime = Date.parse(isoTime);
+  return Date.now() < expirationTime;
+}

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -185,7 +185,7 @@ t.test('CloudSQLInstance', async t => {
           };
           // starts out refresh logic
           instance.refresh();
-          instance.setStablishedConnection();
+          instance.setEstablishedConnection();
         }))();
     }
   );
@@ -239,7 +239,7 @@ t.test('CloudSQLInstance', async t => {
           };
           // starts out refresh logic
           instance.refresh();
-          instance.setStablishedConnection();
+          instance.setEstablishedConnection();
         }))();
     }
   );
@@ -470,7 +470,7 @@ t.test('CloudSQLInstance', async t => {
       });
 
       await instance.refresh();
-      instance.setStablishedConnection();
+      instance.setEstablishedConnection();
 
       // starts a new refresh cycle but do not await on it
       instance.refresh();
@@ -550,7 +550,7 @@ t.test('CloudSQLInstance', async t => {
           };
           // starts out refresh logic
           instance.refresh();
-          instance.setStablishedConnection();
+          instance.setEstablishedConnection();
         }))();
     }
   );

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -150,7 +150,7 @@ t.test('CloudSQLInstance', async t => {
   });
 
   t.test(
-    'refresh error should not throw any errors on stablished connection',
+    'refresh error should not throw any errors on established connection',
     async t => {
       let metadataCount = 0;
       const failedFetcher = {
@@ -191,7 +191,7 @@ t.test('CloudSQLInstance', async t => {
   );
 
   t.test(
-    'refresh error with expired cert should not throw any errors on stablished connection',
+    'refresh error with expired cert should not throw any errors on established connection',
     async t => {
       const {CloudSQLInstance} = t.mock('../src/cloud-sql-instance', {
         '../src/crypto': {
@@ -447,7 +447,7 @@ t.test('CloudSQLInstance', async t => {
   });
 
   t.test(
-    'cancelRefresh on stablished connection and ongoing failed cycle',
+    'cancelRefresh on established connection and ongoing failed cycle',
     async t => {
       let metadataCount = 0;
       const failAndSlowFetcher = {

--- a/test/time.ts
+++ b/test/time.ts
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import t from 'tap';
-import {getRefreshInterval, getNearestExpiration} from '../src/time';
+import {
+  getRefreshInterval,
+  getNearestExpiration,
+  isExpirationTimeValid,
+} from '../src/time';
 
 const datenow = Date.now;
 Date.now = () => 1672567200000; // 2023-01-01T10:00:00.000Z
@@ -120,6 +124,21 @@ t.same(
   getNearestExpiration(Date.parse('2023-01-01T00:00:00.000Z'), undefined),
   new Date(Date.parse('2023-01-01T00:00:00.000Z')).toISOString(),
   'should return cert exp'
+);
+
+t.ok(
+  !isExpirationTimeValid('2023-01-01T09:00:00.000Z'),
+  'should return false on expired time'
+);
+
+t.ok(
+  !isExpirationTimeValid('2023-01-01T10:00:00.000Z'),
+  'should return false on same (expired) time'
+);
+
+t.ok(
+  isExpirationTimeValid('2023-01-01T11:00:00.000Z'),
+  'should return true on valid time'
 );
 
 Date.now = datenow;


### PR DESCRIPTION
When an instance already have active connections, it should not throw errors when trying to refresh cloud instance certificates in the background. Otherwise these errors will bubble up and stop the end user application.

This PR fixes it by adding a more resilient system to the CloudSQLInstance refresh logic that silents errors occured during refresh and keeps valid certificate data that can be used if a refresh is still ongoing or if any error happens when during a refresh.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/201