### PR TITLE
chore: remove node19 from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x, v19.x]
+        node-version: [v14.x, v16.x, v18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -128,7 +128,7 @@ jobs:
     name: System tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x, v19.x]
+        node-version: [v14.x, v16.x, v18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
Removing deprecated node19 version from CI since it's currently having problems to run on GitHub actions.

Refs: https://github.com/actions/setup-node/issues/838