### PR TITLE
feat(SQLAdminFetcher): Support base `AuthClient` for `auth` and `loginAuth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ alternative to the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/mysq
 while providing the following benefits:
 
 - **IAM Authorization:** uses IAM permissions to control who/what can connect to
-your Cloud SQL instances
+  your Cloud SQL instances
 - **Improved Security:** uses robust, updated TLS 1.3 encryption and identity
-verification between the client connector and the server-side proxy,
-independent of the database protocol.
+  verification between the client connector and the server-side proxy,
+  independent of the database protocol.
 - **Convenience:** removes the requirement to use and distribute SSL
-certificates, as well as manage firewalls or source/destination IP addresses.
+  certificates, as well as manage firewalls or source/destination IP addresses.
 - (optionally) **IAM DB Authentication:** provides support for
   [Cloud SQL’s automatic IAM DB AuthN][iam-db-authn] feature.
 
@@ -65,14 +65,14 @@ const {Pool} = pg;
 const connector = new Connector();
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
-  ipType: 'PUBLIC', 
+  ipType: 'PUBLIC',
 });
 const pool = new Pool({
   ...clientOpts,
   user: 'my-user',
   password: 'my-password',
   database: 'db-name',
-  max: 5
+  max: 5,
 });
 const {rows} = await pool.query('SELECT NOW()');
 console.table(rows); // prints returned time value from server
@@ -102,7 +102,7 @@ const pool = await mysql.createPool({
   database: 'db-name',
 });
 const conn = await pool.getConnection();
-const [result] = await conn.query( `SELECT NOW();`);
+const [result] = await conn.query(`SELECT NOW();`);
 console.table(result); // prints returned time value from server
 
 await pool.end();
@@ -121,7 +121,7 @@ const {Connector} = require('@google-cloud/cloud-sql-connector');
 const connector = new Connector();
 const clientOpts = await connector.getTediousOptions({
   instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
-  ipType: 'PUBLIC'
+  ipType: 'PUBLIC',
 });
 const connection = new Connection({
   // Please note that the `server` property here is not used and is only defined
@@ -147,21 +147,29 @@ const connection = new Connection({
     port: 9999,
     database: 'my-database',
   },
-})
+});
 
 connection.connect(err => {
-  if (err) { throw err; }
+  if (err) {
+    throw err;
+  }
   let result;
-  const req = new Request('SELECT GETUTCDATE()', (err) => {
-    if (err) { throw err; }
-  })
-  req.on('error', (err) => { throw err; });
-  req.on('row', (columns) => { result = columns; });
+  const req = new Request('SELECT GETUTCDATE()', err => {
+    if (err) {
+      throw err;
+    }
+  });
+  req.on('error', err => {
+    throw err;
+  });
+  req.on('row', columns => {
+    result = columns;
+  });
   req.on('requestCompleted', () => {
     console.table(result);
   });
   connection.execSql(req);
-})
+});
 
 connection.close();
 connector.close();
@@ -172,8 +180,8 @@ connector.close();
 The Cloud SQL Connector for Node.js can be used to connect to Cloud SQL
 instances using both public and private IP addresses, as well as
 [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect)
- (PSC). Specifying which IP address type to connect to can be configured within
- `getOptions` through the `ipType` argument.
+(PSC). Specifying which IP address type to connect to can be configured within
+`getOptions` through the `ipType` argument.
 
 By default, connections will be configured to `'PUBLIC'` and connect over
 public IP, to configure connections to use an instance's private IP,
@@ -205,7 +213,7 @@ const clientOpts = await connector.getOptions({
 #### Example on how to use `IpAddressTypes` in TypeScript
 
 ```js
-import { Connector, IpAddressTypes } from '@google-cloud/cloud-sql-connector';
+import {Connector, IpAddressTypes} from '@google-cloud/cloud-sql-connector';
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
   ipType: IpAddressTypes.PSC,
@@ -227,12 +235,13 @@ automatic IAM database authentication with `getOptions` through the
 ```js
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
-  authType: 'IAM'
+  authType: 'IAM',
 });
 ```
 
 When configuring a connection for IAM authentication, the `password` argument
 can be omitted and the `user` argument should be formatted as follows:
+
 > Postgres: For an IAM user account, this is the user's email address.
 > For a service account, it is the service account's email without the
 > `.gserviceaccount.com` domain suffix.
@@ -260,13 +269,13 @@ const {Pool} = pg;
 const connector = new Connector();
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
-  authType: 'IAM'
+  authType: 'IAM',
 });
 const pool = new Pool({
   ...clientOpts,
   user: 'test-sa@test-project.iam',
   database: 'db-name',
-  max: 5
+  max: 5,
 });
 const {rows} = await pool.query('SELECT NOW()');
 console.table(rows); // prints returned time value from server
@@ -284,7 +293,7 @@ import {Connector} from '@google-cloud/cloud-sql-connector';
 const connector = new Connector();
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
-  authType: 'IAM'
+  authType: 'IAM',
 });
 const pool = await mysql.createPool({
   ...clientOpts,
@@ -292,7 +301,7 @@ const pool = await mysql.createPool({
   database: 'db-name',
 });
 const conn = await pool.getConnection();
-const [result] = await conn.query( `SELECT NOW();`);
+const [result] = await conn.query(`SELECT NOW();`);
 console.table(result); // prints returned time value from server
 
 await pool.end();
@@ -305,10 +314,29 @@ For TypeScript users, the `AuthTypes` type can be imported and used directly
 for automatic IAM database authentication.
 
 ```js
-import { AuthTypes, Connector } from '@google-cloud/cloud-sql-connector';
+import {AuthTypes, Connector} from '@google-cloud/cloud-sql-connector';
 const clientOpts = await connector.getOptions({
   instanceConnectionName: 'my-project:region:my-instance',
   authType: AuthTypes.IAM,
+});
+```
+
+## Using With `Google Auth Library: Node.js Client` Credentials
+
+One can use [`google-auth-library`](https://github.com/googleapis/google-auth-library-nodejs/) credentials
+with this library by providing an `AuthClient` or `GoogleAuth` instance to the `Connector`.
+
+```sh
+npm install google-auth-library
+```
+
+```js
+const {GoogleAuth} = require('google-auth-library');
+
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+
+const connector = new Connector({
+  loginAuth: new GoogleAuth(),
 });
 ```
 
@@ -318,11 +346,11 @@ It is possible to change some of the library default behavior via environment
 variables. Here is a quick reference to supported values and their effect:
 
 - `GOOGLE_APPLICATION_CREDENTIALS`: If defined the connector will use this
-file as a custom credential files to authenticate to Cloud SQL APIs. Should be
-a path to a JSON file. You can
-[find more on how to get a valid credentials file here][credentials-json-file].
+  file as a custom credential files to authenticate to Cloud SQL APIs. Should be
+  a path to a JSON file. You can
+  [find more on how to get a valid credentials file here][credentials-json-file].
 - `GOOGLE_CLOUD_QUOTA_PROJECT`: Used to set a custom quota project to Cloud SQL
-APIs when defined.
+  APIs when defined.
 
 ## Support policy
 
@@ -354,9 +382,9 @@ update as soon as possible to an actively supported LTS version.
 Google's client libraries support legacy versions of Node.js runtimes on a
 best-efforts basis with the following warnings:
 
-* Legacy versions are not tested in continuous integration.
-* Some security patches and features cannot be backported.
-* Dependencies cannot be kept up-to-date.
+- Legacy versions are not tested in continuous integration.
+- Some security patches and features cannot be backported.
+- Dependencies cannot be kept up-to-date.
 
 ### Release cadence
 

--- a/README.md
+++ b/README.md
@@ -331,12 +331,11 @@ npm install google-auth-library
 ```
 
 ```js
-const {GoogleAuth} = require('google-auth-library');
-
-const {Connector} = require('@google-cloud/cloud-sql-connector');
+import {GoogleAuth} from 'google-auth-library';
+import {Connector} from '@google-cloud/cloud-sql-connector';
 
 const connector = new Connector({
-  loginAuth: new GoogleAuth(),
+  auth: new GoogleAuth(),
 });
 ```
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -17,7 +17,7 @@ import {CloudSQLInstance} from './cloud-sql-instance';
 import {getSocket} from './socket';
 import {IpAddressTypes} from './ip-addresses';
 import {AuthTypes} from './auth-types';
-import {SQLAdminFetcher} from './sqladmin-fetcher';
+import {SQLAdminFetcher, SQLAdminFetcherOptions} from './sqladmin-fetcher';
 import {CloudSQLConnectorError} from './errors';
 
 // ConnectionOptions are the arguments that the user can provide
@@ -146,9 +146,7 @@ class CloudSQLInstanceMap extends Map {
   }
 }
 
-interface ConnectorOptions {
-  sqlAdminAPIEndpoint?: string;
-}
+interface ConnectorOptions extends SQLAdminFetcherOptions {}
 
 // The Connector class is the main public API to interact
 // with the Cloud SQL Node.js Connector.
@@ -156,9 +154,9 @@ export class Connector {
   private readonly instances: CloudSQLInstanceMap;
   private readonly sqlAdminFetcher: SQLAdminFetcher;
 
-  constructor({sqlAdminAPIEndpoint}: ConnectorOptions = {}) {
+  constructor(opts: ConnectorOptions = {}) {
     this.instances = new CloudSQLInstanceMap();
-    this.sqlAdminFetcher = new SQLAdminFetcher({sqlAdminAPIEndpoint});
+    this.sqlAdminFetcher = new SQLAdminFetcher(opts);
   }
 
   // Connector.getOptions is a method that accepts a Cloud SQL instance

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import tls from 'node:tls';
+import {AuthClient, GoogleAuth} from 'google-auth-library';
 import {CloudSQLInstance} from './cloud-sql-instance';
 import {getSocket} from './socket';
 import {IpAddressTypes} from './ip-addresses';
 import {AuthTypes} from './auth-types';
-import {SQLAdminFetcher, SQLAdminFetcherOptions} from './sqladmin-fetcher';
+import {SQLAdminFetcher} from './sqladmin-fetcher';
 import {CloudSQLConnectorError} from './errors';
 
 // ConnectionOptions are the arguments that the user can provide
@@ -146,7 +147,10 @@ class CloudSQLInstanceMap extends Map {
   }
 }
 
-interface ConnectorOptions extends SQLAdminFetcherOptions {}
+interface ConnectorOptions {
+  auth?: GoogleAuth<AuthClient> | AuthClient;
+  sqlAdminAPIEndpoint?: string;
+}
 
 // The Connector class is the main public API to interact
 // with the Cloud SQL Node.js Connector.
@@ -156,7 +160,10 @@ export class Connector {
 
   constructor(opts: ConnectorOptions = {}) {
     this.instances = new CloudSQLInstanceMap();
-    this.sqlAdminFetcher = new SQLAdminFetcher(opts);
+    this.sqlAdminFetcher = new SQLAdminFetcher({
+      loginAuth: opts.auth,
+      sqlAdminAPIEndpoint: opts.sqlAdminAPIEndpoint,
+    });
   }
 
   // Connector.getOptions is a method that accepts a Cloud SQL instance

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -69,7 +69,6 @@ function cleanGaxiosConfig() {
 }
 
 export interface SQLAdminFetcherOptions {
-  auth?: GoogleAuth<AuthClient> | AuthClient;
   loginAuth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
 }

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GoogleAuth} from 'google-auth-library';
+import {AuthClient, GoogleAuth} from 'google-auth-library';
 import {sqladmin_v1beta4} from '@googleapis/sqladmin';
 import {instance as gaxios} from 'gaxios';
 const {Sqladmin} = sqladmin_v1beta4;
@@ -69,13 +69,13 @@ function cleanGaxiosConfig() {
 }
 
 export interface SQLAdminFetcherOptions {
-  loginAuth?: GoogleAuth;
+  loginAuth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
 }
 
 export class SQLAdminFetcher {
   private readonly client: sqladmin_v1beta4.Sqladmin;
-  private readonly auth: GoogleAuth;
+  private readonly auth: GoogleAuth<AuthClient>;
 
   constructor({loginAuth, sqlAdminAPIEndpoint}: SQLAdminFetcherOptions = {}) {
     const auth = new GoogleAuth({
@@ -92,11 +92,14 @@ export class SQLAdminFetcher {
       ],
     });
 
-    this.auth =
-      loginAuth ||
-      new GoogleAuth({
+    if (loginAuth instanceof GoogleAuth) {
+      this.auth = loginAuth;
+    } else {
+      this.auth = new GoogleAuth({
+        authClient: loginAuth, // either an `AuthClient` or undefined
         scopes: ['https://www.googleapis.com/auth/sqlservice.login'],
       });
+    }
   }
 
   async getInstanceMetadata({

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -69,6 +69,7 @@ function cleanGaxiosConfig() {
 }
 
 export interface SQLAdminFetcherOptions {
+  auth?: GoogleAuth<AuthClient> | AuthClient;
   loginAuth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
 }
@@ -78,12 +79,22 @@ export class SQLAdminFetcher {
   private readonly auth: GoogleAuth<AuthClient>;
 
   constructor({loginAuth, sqlAdminAPIEndpoint}: SQLAdminFetcherOptions = {}) {
-    const auth = new GoogleAuth({
-      scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
-    });
+    let auth: GoogleAuth<AuthClient>;
+
+    if (loginAuth instanceof GoogleAuth) {
+      auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
+      });
+    } else {
+      auth = new GoogleAuth({
+        authClient: loginAuth, // either an `AuthClient` or undefined
+        scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
+      });
+    }
+
     this.client = new Sqladmin({
       rootUrl: sqlAdminAPIEndpoint,
-      auth,
+      auth: auth as GoogleAuth,
       userAgentDirectives: [
         {
           product: 'cloud-sql-nodejs-connector',

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -15,7 +15,7 @@
 import {resolve} from 'node:path';
 import t from 'tap';
 import nock from 'nock';
-import {GoogleAuth} from 'google-auth-library';
+import {GoogleAuth, OAuth2Client} from 'google-auth-library';
 import {sqladmin_v1beta4} from '@googleapis/sqladmin';
 import {SQLAdminFetcher} from '../src/sqladmin-fetcher';
 import {InstanceConnectionInfo} from '../src/instance-connection-info';
@@ -70,6 +70,28 @@ const mockRequest = (
       ...overrides,
     });
 };
+
+t.test('constructor', async t => {
+  t.test('should support GoogleAuth for `auth`', async t => {
+    const auth = new GoogleAuth();
+    new SQLAdminFetcher({auth});
+  });
+
+  t.test('should support `AuthClient` for `auth`', async t => {
+    const authClient = new OAuth2Client();
+    new SQLAdminFetcher({auth: authClient});
+  });
+
+  t.test('should support GoogleAuth for `loginAuth`', async t => {
+    const auth = new GoogleAuth();
+    new SQLAdminFetcher({loginAuth: auth});
+  });
+
+  t.test('should support `AuthClient` for `loginAuth`', async t => {
+    const authClient = new OAuth2Client();
+    new SQLAdminFetcher({loginAuth: authClient});
+  });
+});
 
 t.test('getInstanceMetadata', async t => {
   setupCredentials(t);

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -72,22 +72,12 @@ const mockRequest = (
 };
 
 t.test('constructor', async t => {
-  t.test('should support GoogleAuth for `auth`', async t => {
-    const auth = new GoogleAuth();
-    new SQLAdminFetcher({auth});
-  });
-
-  t.test('should support `AuthClient` for `auth`', async t => {
-    const authClient = new OAuth2Client();
-    new SQLAdminFetcher({auth: authClient});
-  });
-
-  t.test('should support GoogleAuth for `loginAuth`', async t => {
+  t.test('should support GoogleAuth for `loginAuth`', () => {
     const auth = new GoogleAuth();
     new SQLAdminFetcher({loginAuth: auth});
   });
 
-  t.test('should support `AuthClient` for `loginAuth`', async t => {
+  t.test('should support `AuthClient` for `loginAuth`', () => {
     const authClient = new OAuth2Client();
     new SQLAdminFetcher({loginAuth: authClient});
   });

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -72,14 +72,14 @@ const mockRequest = (
 };
 
 t.test('constructor', async t => {
-  t.test('should support GoogleAuth for `loginAuth`', () => {
+  await t.test('should support GoogleAuth for `loginAuth`', async t => {
     const auth = new GoogleAuth();
-    new SQLAdminFetcher({loginAuth: auth});
+    t.ok(new SQLAdminFetcher({loginAuth: auth}));
   });
 
-  t.test('should support `AuthClient` for `loginAuth`', () => {
+  await t.test('should support `AuthClient` for `loginAuth`', async t => {
     const authClient = new OAuth2Client();
-    new SQLAdminFetcher({loginAuth: authClient});
+    t.ok(new SQLAdminFetcher({loginAuth: authClient}));
   });
 });
 


### PR DESCRIPTION
## Change Description

Adds custom auth support for `auth` and `loginAuth`.

## Checklist

- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #200
