### PR TITLE
fix: cloud-sql-instance promise chaining

### DIFF
--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -113,7 +113,7 @@ t.test('CloudSQLInstance', async t => {
       limitRateInterval: 50,
     });
 
-    t.rejects(
+    await t.rejects(
       instance.refresh(),
       /ERR/,
       'should raise the specific error to the end user'


### PR DESCRIPTION
Mixing async/await syntax with thenable method chaining was leading to a promise chain that can potentially error with no handler, resulting in a possible unhandled rejection.

This PR fixes it by making sure a single promise chain is returned in place.