### PR TITLE
chore: add port option to tls server test helper

### DIFF
--- a/test/fixtures/setup-tls-server.ts
+++ b/test/fixtures/setup-tls-server.ts
@@ -15,7 +15,10 @@
 import {createServer} from 'node:https';
 import {CA_CERT, SERVER_CERT, SERVER_KEY} from './certs';
 
-export async function setupTLSServer(t: Tap.Test): Promise<void> {
+export async function setupTLSServer(
+  t: Tap.Test,
+  port?: number
+): Promise<void> {
   const server = createServer(
     {
       ca: CA_CERT,
@@ -29,7 +32,7 @@ export async function setupTLSServer(t: Tap.Test): Promise<void> {
     }
   );
   await new Promise((res): void => {
-    server.listen(3307, () => {
+    server.listen(port || 3307, () => {
       res(null);
     });
   });

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -19,7 +19,9 @@ import {CA_CERT, CLIENT_CERT, CLIENT_KEY} from './fixtures/certs';
 import {setupTLSServer} from './fixtures/setup-tls-server';
 
 t.test('getSocket', async t => {
-  await setupTLSServer(t);
+  // the mock tls server for this test will use a custom port in order
+  // to avoid conflicting ports with the integration tests
+  await setupTLSServer(t, 3001);
 
   await new Promise((res, rej): void => {
     const socket = getSocket({
@@ -33,7 +35,7 @@ t.test('getSocket', async t => {
         expirationTime: '2033-01-06T10:00:00.232Z',
       },
       host: '127.0.0.1',
-      port: 3307,
+      port: 3001, // using port 3001 here to avoid EADDRINUSE errors
       privateKey: CLIENT_KEY,
       serverCaCert: {
         cert: CA_CERT,


### PR DESCRIPTION
While updating to the new version of our test framework, the tests would start occasionally fail with an `EADDRINUSE` error from trying to connect to an already in use port.

This changeset adds an option to the `setup-tls-server` helper module so that we can use different ports in different files that may be run in parallel.