### PR TITLE
chore: fix node14 ci target install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
       # once node@14 is no longer supported
       - name: Setup v14.x-compatible tap
         if: "${{ matrix.node-version == 'v14.x' }}"
-        run: npm uninstall tap && npm install tap@16 ts-node && npx npm@7 pkg delete tap
+        run: npm uninstall @typescript-eslint/eslint-plugin eslint-plugin-prettier tap && npm install tap@16 ts-node && npx npm@7 pkg delete tap
 
       - name: Run Tests v14.x
         if: "${{ matrix.node-version == 'v14.x' }}"
@@ -234,7 +234,7 @@ jobs:
       # once node@14 is no longer supported
       - name: Setup v14.x-compatible tap
         if: "${{ matrix.node-version == 'v14.x' }}"
-        run: npm uninstall tap && npm install tap@16 ts-node && npx npm@7 pkg delete tap
+        run: npm uninstall @typescript-eslint/eslint-plugin eslint-plugin-prettier tap && npm install tap@16 ts-node && npx npm@7 pkg delete tap
 
       - name: Run System Tests v14.x
         env:


### PR DESCRIPTION
npm6 is having trouble installing eslint-related dependencies ([ref](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/actions/runs/6958954655/job/18935508926?pr=255))

This uninstalls any eslint-related deps since they're not used by the unit or system test ci targets in order to fix builds.
