### PR TITLE
chore: add node20 ci target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x]
+        node-version: [v14.x, v16.x, v18.x, v20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -145,7 +145,7 @@ jobs:
     name: System tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x]
+        node-version: [v14.x, v16.x, v18.x, v20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
Node.js v20 is the [current active LTS version](https://github.com/nodejs/Release#release-schedule) and we should have it as part of our test matrix.