### PR TITLE
chore: fix database name on knex examples

### DIFF
--- a/examples/knex/mysql2/connect.cjs
+++ b/examples/knex/mysql2/connect.cjs
@@ -28,7 +28,7 @@ async function connect({ instanceConnectionName, user, databaseName }) {
     connection: {
       ...clientOpts,
       user,
-      databaseName,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/mysql2/connect.mjs
+++ b/examples/knex/mysql2/connect.mjs
@@ -15,7 +15,7 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import knex from 'knex';
 
-export async function connect({ instanceConnectionName, user, db }) {
+export async function connect({ instanceConnectionName, user, databaseName }) {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName,
@@ -28,7 +28,7 @@ export async function connect({ instanceConnectionName, user, db }) {
     connection: {
       ...clientOpts,
       user,
-      db,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/mysql2/connect.ts
+++ b/examples/knex/mysql2/connect.ts
@@ -19,7 +19,7 @@ import {
 } from '@google-cloud/cloud-sql-connector';
 import knex from 'knex';
 
-export async function connect({instanceConnectionName, user, db}) {
+export async function connect({instanceConnectionName, user, databaseName}) {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName,
@@ -32,7 +32,7 @@ export async function connect({instanceConnectionName, user, db}) {
     connection: {
       ...clientOpts,
       user,
-      db,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/mysql2/test/connect.cjs
+++ b/examples/knex/mysql2/test/connect.cjs
@@ -19,7 +19,7 @@ t.test('mysql knex cjs', async t => {
   const {database, close} = await connect({
     instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
     user: process.env.MYSQL_IAM_USER,
-    db: process.env.MYSQL_DB,
+    databaseName: process.env.MYSQL_DB,
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/mysql2/test/connect.mjs
+++ b/examples/knex/mysql2/test/connect.mjs
@@ -19,7 +19,7 @@ t.test('mysql knex mjs', async t => {
   const {database, close} = await connect({
     instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
     user: process.env.MYSQL_IAM_USER,
-    db: process.env.MYSQL_DB,
+    databaseName: process.env.MYSQL_DB,
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/mysql2/test/connect.ts
+++ b/examples/knex/mysql2/test/connect.ts
@@ -19,7 +19,7 @@ t.test('mysql knex ts', async t => {
   const {database, close} = await connect({
     instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
     user: process.env.MYSQL_IAM_USER,
-    db: process.env.MYSQL_DB,
+    databaseName: process.env.MYSQL_DB,
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/pg/connect.cjs
+++ b/examples/knex/pg/connect.cjs
@@ -15,7 +15,7 @@
 const {Connector} = require('@google-cloud/cloud-sql-connector');
 const knex = require('knex');
 
-async function connect({ instanceConnectionName, user, db }) {
+async function connect({ instanceConnectionName, user, databaseName }) {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName,
@@ -28,7 +28,7 @@ async function connect({ instanceConnectionName, user, db }) {
     connection: {
       ...clientOpts,
       user,
-      database: db,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/pg/connect.mjs
+++ b/examples/knex/pg/connect.mjs
@@ -15,7 +15,7 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import knex from 'knex';
 
-export async function connect({ instanceConnectionName, user, db }) {
+export async function connect({ instanceConnectionName, user, databaseName }) {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName,
@@ -28,7 +28,7 @@ export async function connect({ instanceConnectionName, user, db }) {
     connection: {
       ...clientOpts,
       user,
-      database: db,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/pg/connect.ts
+++ b/examples/knex/pg/connect.ts
@@ -22,11 +22,11 @@ import knex from 'knex';
 export async function connect({
   instanceConnectionName,
   user,
-  db,
+  databaseName,
 }: {
   instanceConnectionName: string;
   user: string;
-  db: string;
+  databaseName: string;
 }) {
   const connector = new Connector();
   const clientOpts = await connector.getOptions({
@@ -40,7 +40,7 @@ export async function connect({
     connection: {
       ...clientOpts,
       user,
-      database: db,
+      database: databaseName,
     },
   });
 

--- a/examples/knex/pg/test/connect.cjs
+++ b/examples/knex/pg/test/connect.cjs
@@ -19,7 +19,7 @@ t.test('pg knex cjs', async t => {
   const {database, close} = await connect({
     instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
     user: process.env.POSTGRES_IAM_USER,
-    db: process.env.POSTGRES_DB,
+    databaseName: process.env.POSTGRES_DB,
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/pg/test/connect.mjs
+++ b/examples/knex/pg/test/connect.mjs
@@ -19,7 +19,7 @@ t.test('pg knex mjs', async t => {
   const {database, close} = await connect({
     instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
     user: process.env.POSTGRES_IAM_USER,
-    db: process.env.POSTGRES_DB,
+    databaseName: process.env.POSTGRES_DB,
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/pg/test/connect.ts
+++ b/examples/knex/pg/test/connect.ts
@@ -19,7 +19,7 @@ t.test('pg knex ts', async t => {
   const {database, close} = await connect({
     instanceConnectionName: String(process.env.POSTGRES_IAM_CONNECTION_NAME),
     user: String(process.env.POSTGRES_IAM_USER),
-    db: String(process.env.POSTGRES_DB),
+    databaseName: String(process.env.POSTGRES_DB),
   });
   const {now} = await database.first(database.raw('NOW() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/tedious/connect.cjs
+++ b/examples/knex/tedious/connect.cjs
@@ -15,7 +15,7 @@
 const {Connector} = require('@google-cloud/cloud-sql-connector');
 const knex = require('knex');
 
-async function connect({ instanceConnectionName, user, password, db }) {
+async function connect({ instanceConnectionName, user, password, databaseName }) {
   const connector = new Connector();
   const clientOpts = await connector.getTediousOptions({
     instanceConnectionName,
@@ -33,7 +33,7 @@ async function connect({ instanceConnectionName, user, password, db }) {
       server: '0.0.0.0',
       user,
       password,
-      database: db,
+      database: databaseName,
       options: {
         ...clientOpts,
       },

--- a/examples/knex/tedious/connect.mjs
+++ b/examples/knex/tedious/connect.mjs
@@ -15,7 +15,7 @@
 import {Connector} from '@google-cloud/cloud-sql-connector';
 import knex from 'knex';
 
-export async function connect({ instanceConnectionName, user, password, db }) {
+export async function connect({ instanceConnectionName, user, password, databaseName }) {
   const connector = new Connector();
   const clientOpts = await connector.getTediousOptions({
     instanceConnectionName,
@@ -33,7 +33,7 @@ export async function connect({ instanceConnectionName, user, password, db }) {
       server: '0.0.0.0',
       user,
       password,
-      database: db,
+      database: databaseName,
       options: {
         ...clientOpts,
       },

--- a/examples/knex/tedious/connect.ts
+++ b/examples/knex/tedious/connect.ts
@@ -19,7 +19,12 @@ import {
 } from '@google-cloud/cloud-sql-connector';
 import knex from 'knex';
 
-export async function connect({instanceConnectionName, user, password, db}) {
+export async function connect({
+  instanceConnectionName,
+  user,
+  password,
+  databaseName,
+}) {
   const connector = new Connector();
   const clientOpts = await connector.getTediousOptions({
     instanceConnectionName,
@@ -37,7 +42,7 @@ export async function connect({instanceConnectionName, user, password, db}) {
       server: '0.0.0.0',
       user,
       password,
-      database: db,
+      database: databaseName,
       options: {
         ...clientOpts,
       },

--- a/examples/knex/tedious/test/connect.cjs
+++ b/examples/knex/tedious/test/connect.cjs
@@ -20,7 +20,7 @@ t.test('tedious knex cjs', async t => {
     instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
     user: process.env.SQLSERVER_USER,
     password: process.env.SQLSERVER_PASS,
-    database: process.env.SQLSERVER_DB,
+    databaseName: process.env.SQLSERVER_DB,
   });
   const {now} = await database.first(database.raw('GETUTCDATE() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/tedious/test/connect.mjs
+++ b/examples/knex/tedious/test/connect.mjs
@@ -20,7 +20,7 @@ t.test('tedious knex mjs', async t => {
     instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
     user: process.env.SQLSERVER_USER,
     password: process.env.SQLSERVER_PASS,
-    database: process.env.SQLSERVER_DB,
+    databaseName: process.env.SQLSERVER_DB,
   });
   const {now} = await database.first(database.raw('GETUTCDATE() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');

--- a/examples/knex/tedious/test/connect.ts
+++ b/examples/knex/tedious/test/connect.ts
@@ -20,7 +20,7 @@ t.test('tedious knex ts', async t => {
     instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
     user: process.env.SQLSERVER_USER,
     password: process.env.SQLSERVER_PASS,
-    database: process.env.SQLSERVER_DB,
+    databaseName: process.env.SQLSERVER_DB,
   });
   const {now} = await database.first(database.raw('GETUTCDATE() AS now'));
   t.ok(now.getTime(), 'should have valid returned date object');


### PR DESCRIPTION
Fixes a naming mistake on `knex` examples.