### PR TITLE
docs: add details to further examples for `GoogleAuth` credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ const connector = new Connector({
 });
 ```
 
-This can be extremely useful to leverage the `Connector` with a service account that differs from that
+This can be useful to leverage the `Connector` with a service account that differs from that
 of the Application Default Credentials.
 
 The below example showcases how to initialize a `Connector` from a service account key that is

--- a/README.md
+++ b/README.md
@@ -383,12 +383,11 @@ if (!keysEnvVar) {
 }
 const keys = JSON.parse(keysEnvVar);
 
-const auth = new GoogleAuth({
-    scopes: ['https://www.googleapis.com/auth/sqlservice.admin']
-});
-
 const connector = new Connector({
-    auth: auth.fromJSON(keys),
+  auth: new GoogleAuth({
+    credentials: keys,
+    scopes: ['https://www.googleapis.com/auth/sqlservice.admin']
+  }),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -367,29 +367,8 @@ const connector = new Connector({
 ```
 
 This can be useful when configuring credentials that differ from
-Application Default Credentials.
-
-The below example showcases how to initialize a `Connector` from a service account key that is
-[loaded into an environment variable][google-auth-load-creds].
-
-```js
-import {Connector} from '@google-cloud/cloud-sql-connector';
-import {GoogleAuth} from 'google-auth-library';
-
-// load the environment variable with our keys
-const keysEnvVar = process.env.CREDS
-if (!keysEnvVar) {
-  throw new Error('The $CREDS environment variable was not found!');
-}
-const keys = JSON.parse(keysEnvVar);
-
-const connector = new Connector({
-  auth: new GoogleAuth({
-    credentials: keys,
-    scopes: ['https://www.googleapis.com/auth/sqlservice.admin']
-  }),
-});
-```
+Application Default Credentials. See the [documentation][google-auth-creds]
+on the `google-auth-library` for more information.
 
 ## Additional customization via Environment Variables
 
@@ -456,4 +435,4 @@ Apache Version 2.0
 See [LICENSE](./LICENSE)
 
 [credentials-json-file]: https://github.com/googleapis/google-cloud-node#download-your-service-account-credentials-json-file
-[google-auth-load-creds]: https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#loading-credentials-from-environment-variables
+[google-auth-creds]: https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#loading-credentials-from-environment-variables

--- a/README.md
+++ b/README.md
@@ -366,8 +366,8 @@ const connector = new Connector({
 });
 ```
 
-This can be useful to leverage the `Connector` with a service account that differs from that
-of the Application Default Credentials.
+This can be useful when configuring credentials that differ from
+Application Default Credentials.
 
 The below example showcases how to initialize a `Connector` from a service account key that is
 [loaded into an environment variable][google-auth-load-creds].

--- a/README.md
+++ b/README.md
@@ -362,7 +362,9 @@ import {GoogleAuth} from 'google-auth-library';
 import {Connector} from '@google-cloud/cloud-sql-connector';
 
 const connector = new Connector({
-  auth: new GoogleAuth(),
+  auth: new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/sqlservice.admin']
+  }),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,32 @@ const connector = new Connector({
 });
 ```
 
+This can be extremely useful to leverage the `Connector` with a service account that differs from that
+of the Application Default Credentials.
+
+The below example showcases how to initialize a `Connector` from a service account key that is
+[loaded into an environment variable][google-auth-load-creds].
+
+```js
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {GoogleAuth} from 'google-auth-library';
+
+// load the environment variable with our keys
+const keysEnvVar = process.env.CREDS
+if (!keysEnvVar) {
+  throw new Error('The $CREDS environment variable was not found!');
+}
+const keys = JSON.parse(keysEnvVar);
+
+const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/sqlservice.admin']
+});
+
+const connector = new Connector({
+    auth: auth.fromJSON(keys),
+});
+```
+
 ## Additional customization via Environment Variables
 
 It is possible to change some of the library default behavior via environment
@@ -431,3 +457,4 @@ Apache Version 2.0
 See [LICENSE](./LICENSE)
 
 [credentials-json-file]: https://github.com/googleapis/google-cloud-node#download-your-service-account-credentials-json-file
+[google-auth-load-creds]: https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#loading-credentials-from-environment-variables


### PR DESCRIPTION
Adding a details to examples of using the custom `GoogleAuth` creds with a service account other than ADC. 

Ref: https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#loading-credentials-from-environment-variables

Fixes #272 