### PR TITLE
fix(SQLAdminFetcher): Use `loginAuth` for `auth`

### DIFF
--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -81,9 +81,7 @@ export class SQLAdminFetcher {
     let auth: GoogleAuth<AuthClient>;
 
     if (loginAuth instanceof GoogleAuth) {
-      auth = new GoogleAuth({
-        scopes: ['https://www.googleapis.com/auth/sqlservice.admin'],
-      });
+      auth = loginAuth;
     } else {
       auth = new GoogleAuth({
         authClient: loginAuth, // either an `AuthClient` or undefined


### PR DESCRIPTION
## Change Description

This PR missed a commit to support the supplied `GoogleAuth` for `auth`:
- https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/238

## Checklist

- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- #272
