### PR TITLE
chore: remove support contract reference from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,10 +9,6 @@ labels: 'type: bug'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an
-issue in the [support console](https://cloud.google.com/support/) instead of
-filing on GitHub. This will ensure a timely response.
-
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
   - Search the issues already opened: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -9,10 +9,6 @@ labels: 'type: docs'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an
-issue in the [support console](https://cloud.google.com/support/) instead of
-filing on GitHub. This will ensure a timely response.
-
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
   - Search the issues already opened: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -9,10 +9,6 @@ labels: 'type: feature request'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an
-issue in the [support console](https://cloud.google.com/support/) instead of
-filing on GitHub. This will ensure a timely response.
-
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
   - Search the issues already opened: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,10 +9,6 @@ labels: 'type: question'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an
-issue in the [support console](https://cloud.google.com/support/) instead of
-filing on GitHub. This will ensure a timely response.
-
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
   - Search the issues already opened: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues


### PR DESCRIPTION
If a person has made it to GitHub, they almost certainly have an issue with the library and don't need to circle back to support. By removing this phrase, we don't confuse customers and make it clear that we're happy to engage here. If a customer does in fact have a support issue, we can direct them accordingly.