### PR TITLE
feat: add local proxy tunnel api

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,6 +331,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Prisma on node v16.x and up
+        if: "${{ matrix.node-version != 'v14.x' }}"
+        run: npm install prisma
+
       - name: Setup self-direct dependency
         run: npm link
 
@@ -388,5 +392,5 @@ jobs:
           SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
           SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
-        run: npx tap -c -t0 --disable-coverage --allow-empty-coverage examples/*/{mysql2,pg,tedious}/test/*{.cjs,.mjs,.ts} -o test_results.tap
+        run: npx tap -c -t0 --disable-coverage --allow-empty-coverage examples/*/*/test/*{.cjs,.mjs,.ts} -o test_results.tap
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -202,6 +202,41 @@ connection.close();
 connector.close();
 ```
 
+### Using a Local Proxy Tunnel
+
+Another possible way to use the Cloud SQL Node.js Connector creating a
+local proxy server that creates a tunnel to the secured connection stablished
+using the `Connector.startLocalProxy()` method instead of
+`Connector.getOptions()`.
+
+This alternative approach enables usage of the Connector library with
+unsupported drivers such as [Prisma](https://www.prisma.io/). Here is an
+example on how to use it with its PostgreSQL driver:
+
+```js
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+const connector = new Connector();
+await connector.startLocalProxy({
+  instanceConnectionName: 'my-project:us-east1:my-instance',
+  listenOptions: { path: '.s.PGSQL.5432' },
+});
+const hostPath = process.cwd();
+
+const datasourceUrl =
+ `postgresql://my-user:password@localhost/dbName?host=${hostPath}`;
+const prisma = new PrismaClient({ datasourceUrl });
+
+connector.close();
+await prisma.$disconnect();
+```
+
+Note: When using **Prisma**, each driver has its own way to properly configure
+the `listenOptions` and `datasourceUrl` combinations depending on the database
+type. For examples on each of the supported Cloud SQL databases consult our
+[Prisma samples](./examples/README.md#prisma).
+
 ### Specifying IP Address Type
 
 The Cloud SQL Connector for Node.js can be used to connect to Cloud SQL

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ connector.close();
 
 ### Using a Local Proxy Tunnel
 
-Another possible way to use the Cloud SQL Node.js Connector creating a
-local proxy server that creates a tunnel to the secured connection stablished
+Another possible way to use the Cloud SQL Node.js Connector is by creating a
+local proxy server that tunnels to the secured connection established
 using the `Connector.startLocalProxy()` method instead of
 `Connector.getOptions()`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,18 @@ some of the most popular database libraries and frameworks.
 
 ## Available Examples
 
+### Prisma
+
+- [MySQL (CommonJS)](./prisma/mysql/connect.cjs)
+- [MySQL (ESM)](./prisma/mysql/connect.mjs)
+- [MySQL (TypeScript)](./prisma/mysql/connect.ts)
+- [PostgreSQL (CommonJS)](./prisma/postgresql/connect.cjs)
+- [PostgreSQL (ESM)](./prisma/postgresql/connect.mjs)
+- [PostgreSQL (TypeScript)](./prisma/postgresql/connect.ts)
+- [SQL Server (CommonJS)](./prisma/sqlserver/connect.cjs)
+- [SQL Server (ESM)](./prisma/sqlserver/connect.mjs)
+- [SQL Server (TypeScript)](./prisma/sqlserver/connect.ts)
+
 ### Knex
 
 - [MySQL (CommonJS)](./knex/mysql2/connect.cjs)

--- a/examples/prisma/mysql/connect.cjs
+++ b/examples/prisma/mysql/connect.cjs
@@ -1,0 +1,44 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {resolve} = require('node:path');
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {PrismaClient} = require('@prisma/client');
+
+async function connect({ instanceConnectionName, user, database }) {
+  const path = resolve('mysql.socket');
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+    listenOptions: {path},
+  });
+
+  const datasourceUrl =
+   `mysql://${user}@localhost/${database}?socket=${path}`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};
+
+module.exports = {
+  connect,
+};

--- a/examples/prisma/mysql/connect.mjs
+++ b/examples/prisma/mysql/connect.mjs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({ instanceConnectionName, user, database }) {
+  const path = resolve('mysql.socket');
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+    listenOptions: {path},
+  });
+
+  const datasourceUrl =
+   `mysql://${user}@localhost/${database}?socket=${path}`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};

--- a/examples/prisma/mysql/connect.ts
+++ b/examples/prisma/mysql/connect.ts
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({instanceConnectionName, user, database}) {
+  const path = resolve('mysql.socket');
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+    listenOptions: {path},
+  });
+
+  const datasourceUrl = `mysql://${user}@localhost/${database}?socket=${path}`;
+  const prisma = new PrismaClient({datasourceUrl});
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    },
+  };
+}

--- a/examples/prisma/mysql/schema.prisma
+++ b/examples/prisma/mysql/schema.prisma
@@ -1,0 +1,12 @@
+datasource db {
+  provider = "mysql"
+  url      = env("DB_URL")
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+}
+
+generator client {
+  provider = "prisma-client-js"
+}

--- a/examples/prisma/mysql/test/connect.cjs
+++ b/examples/prisma/mysql/test/connect.cjs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {execSync} = require('node:child_process');
+const {resolve} = require('node:path');
+const t = require('tap');
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('mysql prisma cjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = require('../connect.cjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
+    user: process.env.MYSQL_IAM_USER,
+    database: process.env.MYSQL_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT NOW() as now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/mysql/test/connect.mjs
+++ b/examples/prisma/mysql/test/connect.mjs
@@ -1,0 +1,44 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import t from 'tap';
+
+function generatePrismaClient() {
+  const p = fileURLToPath(import.meta.url)
+  const __dirname = dirname(p)
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('mysql prisma mjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = await import('../connect.mjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
+    user: process.env.MYSQL_IAM_USER,
+    database: process.env.MYSQL_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT NOW() as now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});
+

--- a/examples/prisma/mysql/test/connect.ts
+++ b/examples/prisma/mysql/test/connect.ts
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import {resolve} from 'node:path';
+import t from 'tap';
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('mysql prisma ts', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {
+    default: {connect},
+  } = await import('../connect.ts');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.MYSQL_IAM_CONNECTION_NAME,
+    user: process.env.MYSQL_IAM_USER,
+    database: process.env.MYSQL_DB,
+  });
+  const [{now}] = await prisma.$queryRaw`SELECT NOW() as now`;
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/postgresql/connect.cjs
+++ b/examples/prisma/postgresql/connect.cjs
@@ -1,0 +1,47 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {resolve} = require('node:path');
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {PrismaClient} = require('@prisma/client');
+
+async function connect({ instanceConnectionName, user, database }) {
+  const path = resolve('.s.PGSQL.5432'); // postgres-required socket filename
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+    listenOptions: {path},
+  });
+
+  // note that the host parameter needs to point to the parent folder of
+  // the socket provided in the `path` Connector option, in this example
+  // that is going to be the current working directory
+  const datasourceUrl =
+   `postgresql://${user}@localhost/${database}?host=${process.cwd()}`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};
+
+module.exports = {
+  connect,
+};

--- a/examples/prisma/postgresql/connect.mjs
+++ b/examples/prisma/postgresql/connect.mjs
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({ instanceConnectionName, user, database }) {
+  const path = resolve('.s.PGSQL.5432'); // postgres-required socket filename
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    authType: 'IAM',
+    listenOptions: {path},
+  });
+
+  // note that the host parameter needs to point to the parent folder of
+  // the socket provided in the `path` Connector option, in this example
+  // that is going to be the current working directory
+  const datasourceUrl =
+   `postgresql://${user}@localhost/${database}?host=${process.cwd()}`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};

--- a/examples/prisma/postgresql/connect.ts
+++ b/examples/prisma/postgresql/connect.ts
@@ -1,0 +1,46 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({instanceConnectionName, user, database}) {
+  const path = resolve('.s.PGSQL.5432'); // postgres-required socket filename
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+    listenOptions: {path},
+  });
+
+  // note that the host parameter needs to point to the parent folder of
+  // the socket provided in the `path` Connector option, in this example
+  // that is going to be the current working directory
+  const datasourceUrl = `postgresql://${user}@localhost/${database}?host=${process.cwd()}`;
+  const prisma = new PrismaClient({datasourceUrl});
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    },
+  };
+}

--- a/examples/prisma/postgresql/schema.prisma
+++ b/examples/prisma/postgresql/schema.prisma
@@ -1,0 +1,12 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DB_URL")
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+}
+
+generator client {
+  provider = "prisma-client-js"
+}

--- a/examples/prisma/postgresql/test/connect.cjs
+++ b/examples/prisma/postgresql/test/connect.cjs
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {execSync} = require('node:child_process');
+const {resolve} = require('node:path');
+const t = require('tap');
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('pg prisma cjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = require('../connect.cjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
+    user: process.env.POSTGRES_IAM_USER,
+    database: process.env.POSTGRES_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT NOW() as now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});
+

--- a/examples/prisma/postgresql/test/connect.mjs
+++ b/examples/prisma/postgresql/test/connect.mjs
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import t from 'tap';
+
+function generatePrismaClient() {
+  const p = fileURLToPath(import.meta.url)
+  const __dirname = dirname(p)
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('pg prisma mjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = await import('../connect.mjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
+    user: process.env.POSTGRES_IAM_USER,
+    database: process.env.POSTGRES_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT NOW() as now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/postgresql/test/connect.ts
+++ b/examples/prisma/postgresql/test/connect.ts
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import {resolve} from 'node:path';
+import t from 'tap';
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('pg prisma ts', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {
+    default: {connect},
+  } = await import('../connect.ts');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.POSTGRES_IAM_CONNECTION_NAME,
+    user: process.env.POSTGRES_IAM_USER,
+    database: process.env.POSTGRES_DB,
+  });
+  const [{now}] = await prisma.$queryRaw`SELECT NOW() as now`;
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/sqlserver/connect.cjs
+++ b/examples/prisma/sqlserver/connect.cjs
@@ -1,0 +1,47 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {resolve} = require('node:path');
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+const {PrismaClient} = require('@prisma/client');
+
+async function connect({ instanceConnectionName, user, password, database }) {
+  const host = 'localhost';
+  const port = 3001;
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    listenOptions: {
+      host,
+      port,
+    },
+  });
+
+  const datasourceUrl =
+   `sqlserver://${host}:${port};user=${user};password=${password};database=${database};encrypt=false;trustServerCertificate=true`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};
+
+module.exports = {
+  connect,
+};

--- a/examples/prisma/sqlserver/connect.mjs
+++ b/examples/prisma/sqlserver/connect.mjs
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {resolve} from 'node:path';
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({ instanceConnectionName, user, password, database }) {
+  const host = 'localhost';
+  const port = 3002;
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: 'PUBLIC',
+    listenOptions: {
+      host,
+      port,
+    },
+  });
+
+  const datasourceUrl =
+   `sqlserver://${host}:${port};user=${user};password=${password};database=${database};encrypt=false;trustServerCertificate=true`;
+  const prisma = new PrismaClient({ datasourceUrl });
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    }
+  };
+};

--- a/examples/prisma/sqlserver/connect.ts
+++ b/examples/prisma/sqlserver/connect.ts
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Connector} from '@google-cloud/cloud-sql-connector';
+import {
+  AuthTypes,
+  Connector,
+  IpAddressTypes,
+} from '@google-cloud/cloud-sql-connector';
+import {PrismaClient} from '@prisma/client';
+
+export async function connect({
+  instanceConnectionName,
+  user,
+  password,
+  database,
+}) {
+  const host = 'localhost';
+  const port = 3003;
+  const connector = new Connector();
+  await connector.startLocalProxy({
+    instanceConnectionName,
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.PASSWORD,
+    listenOptions: {
+      host,
+      port,
+    },
+  });
+
+  const datasourceUrl = `sqlserver://${host}:${port};user=${user};password=${password};database=${database};encrypt=false;trustServerCertificate=true`;
+  const prisma = new PrismaClient({datasourceUrl});
+
+  return {
+    prisma,
+    async close() {
+      await prisma.$disconnect();
+      connector.close();
+    },
+  };
+}

--- a/examples/prisma/sqlserver/schema.prisma
+++ b/examples/prisma/sqlserver/schema.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DB_URL")
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+

--- a/examples/prisma/sqlserver/test/connect.cjs
+++ b/examples/prisma/sqlserver/test/connect.cjs
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {execSync} = require('node:child_process');
+const {resolve} = require('node:path');
+const t = require('tap');
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('sqlserver prisma cjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = require('../connect.cjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
+    user: process.env.SQLSERVER_USER,
+    password: process.env.SQLSERVER_PASS,
+    database: process.env.SQLSERVER_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT GETUTCDATE() AS now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/sqlserver/test/connect.mjs
+++ b/examples/prisma/sqlserver/test/connect.mjs
@@ -1,0 +1,44 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import {dirname, resolve} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import t from 'tap';
+
+function generatePrismaClient() {
+  const p = fileURLToPath(import.meta.url)
+  const __dirname = dirname(p)
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('sqlserver prisma mjs', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {connect} = await import('../connect.mjs');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
+    user: process.env.SQLSERVER_USER,
+    password: process.env.SQLSERVER_PASS,
+    database: process.env.SQLSERVER_DB,
+  });
+  const [{ now }] = await prisma.$queryRaw`SELECT GETUTCDATE() AS now`
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/examples/prisma/sqlserver/test/connect.ts
+++ b/examples/prisma/sqlserver/test/connect.ts
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'node:child_process';
+import {resolve} from 'node:path';
+import t from 'tap';
+
+function generatePrismaClient() {
+  const schemaPath = resolve(__dirname, '../schema.prisma');
+
+  execSync(`npx prisma generate --schema=${schemaPath}`);
+}
+
+t.test('sqlserver prisma ts', async t => {
+  // prisma client generation should normally be part of a regular Prisma
+  // setup on user end but in order to tests in many different databases
+  // we run the generation step at runtime for each variation
+  generatePrismaClient();
+
+  const {
+    default: {connect},
+  } = await import('../connect.ts');
+  const {prisma, close} = await connect({
+    instanceConnectionName: process.env.SQLSERVER_CONNECTION_NAME,
+    user: process.env.SQLSERVER_USER,
+    password: process.env.SQLSERVER_PASS,
+    database: process.env.SQLSERVER_DB,
+  });
+  const [{now}] = await prisma.$queryRaw`SELECT GETUTCDATE() AS now`;
+  t.ok(now.getTime(), 'should have valid returned date object');
+  await close();
+});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   },
   "tap": {
     "serial": [
+      "examples/prisma/mysql",
+      "examples/prisma/postgresql",
       "test/serial"
     ],
     "show-full-coverage": true

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -164,6 +164,11 @@ class CloudSQLInstanceMap extends Map {
 interface ConnectorOptions {
   auth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
+  /**
+   * The Trusted Partner Cloud (TPC) Domain DNS of the service used to make requests.
+   * Defaults to `googleapis.com`.
+   */
+  universeDomain?: string;
 }
 
 // The Connector class is the main public API to interact
@@ -179,6 +184,7 @@ export class Connector {
     this.sqlAdminFetcher = new SQLAdminFetcher({
       loginAuth: opts.auth,
       sqlAdminAPIEndpoint: opts.sqlAdminAPIEndpoint,
+      universeDomain: opts.universeDomain,
     });
     this.localProxies = new Set();
     this.sockets = new Set();
@@ -330,7 +336,11 @@ export class Connector {
     });
 
     const listen = promisify(server.listen) as Function;
-    await listen.call(server, listenOptions);
+    await listen.call(server, {
+      path: listenOptions.path,
+      readableAll: listenOptions.readableAll,
+      writableAll: listenOptions.writableAll,
+    });
   }
 
   // Clear up the event loop from the internal cloud sql

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Connector, ConnectionOptions, DriverOptions} from './connector';
+import {
+  Connector,
+  ConnectionOptions,
+  DriverOptions,
+  TCPSocketOptions,
+  UnixSocketOptions,
+} from './connector';
 import {IpAddressTypes} from './ip-addresses';
 import {AuthTypes} from './auth-types';
 
-export {Connector, type ConnectionOptions, type DriverOptions};
+export {
+  Connector,
+  type ConnectionOptions,
+  type DriverOptions,
+  type TCPSocketOptions,
+  type UnixSocketOptions,
+};
 export {IpAddressTypes};
 export {AuthTypes};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import {
   Connector,
   ConnectionOptions,
   DriverOptions,
-  TCPSocketOptions,
   UnixSocketOptions,
 } from './connector';
 import {IpAddressTypes} from './ip-addresses';
@@ -26,7 +25,6 @@ export {
   Connector,
   type ConnectionOptions,
   type DriverOptions,
-  type TCPSocketOptions,
   type UnixSocketOptions,
 };
 export {IpAddressTypes};

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -558,7 +558,7 @@ t.test('Connector using IAM with Tedious driver', async t => {
   );
 });
 
-t.test('Connector, opens a tunnel local socket', async t => {
+t.test('Connector, opens a tunnel local unix socket', async t => {
   setupCredentials(t); // setup google-auth credentials mocks
 
   // mocks sql admin fetcher and generateKeys modules
@@ -628,6 +628,87 @@ t.test('Connector, opens a tunnel local socket', async t => {
   // Mocks an user connection to the opened local proxy path
   await new Promise((res, rej) => {
     const s = createConnection(path);
+    s.on('ready', () => {
+      s.destroy();
+      res(null);
+    });
+    s.on('error', err => rej(err));
+  });
+
+  // Closes the mocked server and connection
+  server.close();
+
+  // Closes the Connector usage
+  connector.close();
+});
+
+t.test('Connector, opens a tunnel local tcp socket', async t => {
+  setupCredentials(t); // setup google-auth credentials mocks
+
+  // mocks sql admin fetcher and generateKeys modules
+  // so that they can return a deterministic result
+  const {Connector} = t.mockRequire('../src/connector', {
+    '../src/sqladmin-fetcher': {
+      SQLAdminFetcher: class {
+        getInstanceMetadata() {
+          return Promise.resolve({
+            ipAddresses: {
+              public: '127.0.0.1',
+            },
+            serverCaCert: {
+              cert: CA_CERT,
+              expirationTime: '2033-01-06T10:00:00.232Z',
+            },
+          });
+        }
+        getEphemeralCertificate() {
+          return Promise.resolve({
+            cert: CLIENT_CERT,
+            expirationTime: '2033-01-06T10:00:00.232Z',
+          });
+        }
+      },
+    },
+    '../src/cloud-sql-instance': t.mockRequire('../src/cloud-sql-instance', {
+      '../src/crypto': {
+        generateKeys: async () => ({
+          publicKey: '-----BEGIN PUBLIC KEY-----',
+          privateKey: CLIENT_KEY,
+        }),
+      },
+    }),
+  });
+
+  // create a mock server to simulate connecting to a Cloud SQL instance
+  const server = createServer(c => {
+    c.write('foo');
+    c.end('bar');
+  });
+  const listen = promisify(server.listen) as Function;
+  await listen.call(server, {port: 8080, host: '0.0.0.0'});
+
+  // mocks internal getOptions, replacing the returned stream with a direct
+  // socket connection to our mocked server running at port 8080
+  const getOptions = Connector.prototype.getOptions;
+  Connector.prototype.getOptions = () => ({
+    stream: () => createConnection({port: 8080, host: '0.0.0.0'}),
+  });
+  t.teardown(() => {
+    Connector.prototype.getOptions = getOptions; // restore original method
+  });
+
+  // API usage
+  const connector = new Connector();
+  const port = 3000;
+  await connector.startLocalProxy({
+    ipType: 'PUBLIC',
+    instanceConnectionName: 'my-project:us-east1:my-instance',
+    listenOptions: {port},
+  });
+
+  // Mocks an user connection to the opened local proxy
+  await new Promise((res, rej) => {
+    const s = createConnection(3000);
     s.on('ready', () => {
       s.destroy();
       res(null);

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import {EventEmitter} from 'node:events';
+import {createConnection, createServer} from 'node:net';
+import {join, resolve} from 'node:path';
+import {promisify} from 'node:util';
 import t from 'tap';
 import {Connector} from '../src/connector';
 import {setupCredentials} from './fixtures/setup-credentials';
@@ -553,6 +556,90 @@ t.test('Connector using IAM with Tedious driver', async t => {
     },
     'should throw a missing iam support error'
   );
+});
+
+t.test('Connector, opens a tunnel local socket', async t => {
+  setupCredentials(t); // setup google-auth credentials mocks
+
+  // mocks sql admin fetcher and generateKeys modules
+  // so that they can return a deterministic result
+  const {Connector} = t.mockRequire('../src/connector', {
+    '../src/sqladmin-fetcher': {
+      SQLAdminFetcher: class {
+        getInstanceMetadata() {
+          return Promise.resolve({
+            ipAddresses: {
+              public: '127.0.0.1',
+            },
+            serverCaCert: {
+              cert: CA_CERT,
+              expirationTime: '2033-01-06T10:00:00.232Z',
+            },
+          });
+        }
+        getEphemeralCertificate() {
+          return Promise.resolve({
+            cert: CLIENT_CERT,
+            expirationTime: '2033-01-06T10:00:00.232Z',
+          });
+        }
+      },
+    },
+    '../src/cloud-sql-instance': t.mockRequire('../src/cloud-sql-instance', {
+      '../src/crypto': {
+        generateKeys: async () => ({
+          publicKey: '-----BEGIN PUBLIC KEY-----',
+          privateKey: CLIENT_KEY,
+        }),
+      },
+    }),
+  });
+
+  // create a mock server to simulate connecting to a Cloud SQL instance
+  const server = createServer(c => {
+    c.write('foo');
+    c.end('bar');
+  });
+  const listen = promisify(server.listen) as Function;
+  await listen.call(server, {port: 8080, host: '0.0.0.0'});
+
+  // mocks internal getOptions, replacing the returned stream with a direct
+  // socket connection to our mocked server running at port 8080
+  const getOptions = Connector.prototype.getOptions;
+  Connector.prototype.getOptions = () => ({
+    stream: () => createConnection({port: 8080, host: '0.0.0.0'}),
+  });
+  t.teardown(() => {
+    Connector.prototype.getOptions = getOptions; // restore original method
+  });
+
+  // API usage
+  const connector = new Connector();
+  const path =
+    process.platform === 'win32'
+      ? join('\\\\?\\pipe', process.cwd(), 'win.sock')
+      : resolve('tunnel.sock');
+  await connector.startLocalProxy({
+    ipType: 'PUBLIC',
+    instanceConnectionName: 'my-project:us-east1:my-instance',
+    listenOptions: {path},
+  });
+
+  // Mocks an user connection to the opened local proxy path
+  await new Promise((res, rej) => {
+    const s = createConnection(path);
+    s.on('ready', () => {
+      s.destroy();
+      res(null);
+    });
+    s.on('error', err => rej(err));
+  });
+
+  // Closes the mocked server and connection
+  server.close();
+
+  // Closes the Connector usage
+  connector.close();
 });
 
 t.test('Connector force refresh on socket connection error', async t => {


### PR DESCRIPTION
Adds a new `Connector.startLocalProxy` method that starts a local proxy tunnel listening to the location defined at `listenOptions` enabling usage of the Connector by drivers and different libraries / frameworks that are not currently supported by the Connector directly but that can connect to databases via Unix Sockets or TCP port.

Fixes: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/113
