### PR TITLE
chore: add `autorelease: triggered` label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -65,10 +65,12 @@
 - name: 'autorelease: pending'
   color: ededed
   description: Release please needs to do its work on this.
-
 - name: 'autorelease: tagged'
   color: ededed
   description: Release please has completed a release for this.
+- name: 'autorelease: triggered'
+  color: ededed
+  description: Release please has triggered a release for this.
 
 - name: 'tests: run'
   color: 3DED97


### PR DESCRIPTION
Need `autorelease: triggered` to re-trigger release-trigger builds on release PRs