### PR TITLE
ci: pare down tests builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x, v20.x]
+        node-version: [v14.x, v16.x, v20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -145,7 +145,7 @@ jobs:
     name: System tests
     strategy:
       matrix:
-        node-version: [v14.x, v16.x, v18.x, v20.x]
+        node-version: [v14.x, v16.x, v20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
Help reduce quota and flaky tests by reducing test builds being run. Test min and max supported version with the edge case that 14.x is not run on Windows so we will also run 16.x builds.

This should reduce flaky tests due to quota issues surrounding too many builds. If flaky tests are still appearing I will pare down further.

Fixes #265 
Fixes #267 
Fixes #271
Fixes #287 
Fixes #307 
Fixes #319
Fixes #322 
Fixes #323