### PR TITLE
WIP: add `universeDomain` option to Connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@googleapis/sqladmin": "^15.0.0",
         "gaxios": "^6.1.1",
         "google-auth-library": "^9.2.0",
+        "googleapis-common": "^7.1.0",
         "p-throttle": "^5.1.0"
       },
       "devDependencies": {
@@ -4930,14 +4931,14 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.2.0.tgz",
-      "integrity": "sha512-1oV3p0JhNEhVbj26eF3FAJcv9MXXQt4S0wcvKZaDbl4oHq5V3UJoSbsGZGQNcjoCdhW4kDSwOs11wLlHog3fgQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.8.0.tgz",
+      "integrity": "sha512-TJJXFzMlVGRlIH27gYZ6XXyPf5Y3OItsKFfefsDAafNNywYRTkei83nEO29IrYj8GtdHWU78YnW+YZdaZaXIJA==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.0.0",
-        "gcp-metadata": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
@@ -4946,13 +4947,13 @@
       }
     },
     "node_modules/googleapis-common": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.1.tgz",
-      "integrity": "sha512-mgt5zsd7zj5t5QXvDanjWguMdHAcJmmDrF9RkInCecNsyV7S7YtGqm5v2IWONNID88osb7zmx5FtrAP12JfD0w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.1.0.tgz",
+      "integrity": "sha512-p3KHiWDBBWJEXk6SYauBEvxw5+UmRy7k2scxGtsNv9eHsTbpopJ3/7If4OrNnzJ9XMLg3IlyQXpVp8YPQsStiw==",
       "dependencies": {
         "extend": "^3.0.2",
         "gaxios": "^6.0.3",
-        "google-auth-library": "^9.0.0",
+        "google-auth-library": "^9.7.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^9.0.0"
@@ -14588,26 +14589,26 @@
       }
     },
     "google-auth-library": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.2.0.tgz",
-      "integrity": "sha512-1oV3p0JhNEhVbj26eF3FAJcv9MXXQt4S0wcvKZaDbl4oHq5V3UJoSbsGZGQNcjoCdhW4kDSwOs11wLlHog3fgQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.8.0.tgz",
+      "integrity": "sha512-TJJXFzMlVGRlIH27gYZ6XXyPf5Y3OItsKFfefsDAafNNywYRTkei83nEO29IrYj8GtdHWU78YnW+YZdaZaXIJA==",
       "requires": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.0.0",
-        "gcp-metadata": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       }
     },
     "googleapis-common": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.1.tgz",
-      "integrity": "sha512-mgt5zsd7zj5t5QXvDanjWguMdHAcJmmDrF9RkInCecNsyV7S7YtGqm5v2IWONNID88osb7zmx5FtrAP12JfD0w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.1.0.tgz",
+      "integrity": "sha512-p3KHiWDBBWJEXk6SYauBEvxw5+UmRy7k2scxGtsNv9eHsTbpopJ3/7If4OrNnzJ9XMLg3IlyQXpVp8YPQsStiw==",
       "requires": {
         "extend": "^3.0.2",
         "gaxios": "^6.0.3",
-        "google-auth-library": "^9.0.0",
+        "google-auth-library": "^9.7.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@googleapis/sqladmin": "^15.0.0",
     "gaxios": "^6.1.1",
     "google-auth-library": "^9.2.0",
+    "googleapis-common": "^7.1.0",
     "p-throttle": "^5.1.0"
   }
 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import tls from 'node:tls';
-import {AuthClient, GoogleAuth} from 'google-auth-library';
-import {CloudSQLInstance} from './cloud-sql-instance';
-import {getSocket} from './socket';
-import {IpAddressTypes} from './ip-addresses';
-import {AuthTypes} from './auth-types';
-import {SQLAdminFetcher} from './sqladmin-fetcher';
-import {CloudSQLConnectorError} from './errors';
+import { AuthClient, GoogleAuth } from 'google-auth-library';
+import { CloudSQLInstance } from './cloud-sql-instance';
+import { getSocket } from './socket';
+import { IpAddressTypes } from './ip-addresses';
+import { AuthTypes } from './auth-types';
+import { SQLAdminFetcher } from './sqladmin-fetcher';
+import { CloudSQLConnectorError } from './errors';
 
 // ConnectionOptions are the arguments that the user can provide
 // to the Connector.getOptions method when calling it, e.g:
@@ -150,6 +150,11 @@ class CloudSQLInstanceMap extends Map {
 interface ConnectorOptions {
   auth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
+  /**
+  * The Trusted Partner Cloud (TPC) Domain DNS of the service used to make requests.
+  * Defaults to `googleapis.com`.
+  */
+  universeDomain?: string;
 }
 
 // The Connector class is the main public API to interact
@@ -163,6 +168,7 @@ export class Connector {
     this.sqlAdminFetcher = new SQLAdminFetcher({
       loginAuth: opts.auth,
       sqlAdminAPIEndpoint: opts.sqlAdminAPIEndpoint,
+      universeDomain: opts.universeDomain,
     });
   }
 
@@ -182,7 +188,7 @@ export class Connector {
     ipType = IpAddressTypes.PUBLIC,
     instanceConnectionName,
   }: ConnectionOptions): Promise<DriverOptions> {
-    const {instances} = this;
+    const { instances } = this;
     await instances.loadInstance({
       ipType,
       authType,

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AuthClient, GoogleAuth} from 'google-auth-library';
-import {sqladmin_v1beta4} from '@googleapis/sqladmin';
-import {instance as gaxios} from 'gaxios';
-const {Sqladmin} = sqladmin_v1beta4;
-import {InstanceConnectionInfo} from './instance-connection-info';
-import {SslCert} from './ssl-cert';
-import {parseCert} from './crypto';
-import {IpAddresses, parseIpAddresses} from './ip-addresses';
-import {CloudSQLConnectorError} from './errors';
-import {getNearestExpiration} from './time';
-import {AuthTypes} from './auth-types';
+import { AuthClient, GoogleAuth } from 'google-auth-library';
+import { sqladmin_v1beta4 } from '@googleapis/sqladmin';
+import { instance as gaxios } from 'gaxios';
+const { Sqladmin } = sqladmin_v1beta4;
+import { InstanceConnectionInfo } from './instance-connection-info';
+import { SslCert } from './ssl-cert';
+import { parseCert } from './crypto';
+import { IpAddresses, parseIpAddresses } from './ip-addresses';
+import { CloudSQLConnectorError } from './errors';
+import { getNearestExpiration } from './time';
+import { AuthTypes } from './auth-types';
 
 export interface InstanceMetadata {
   ipAddresses: IpAddresses;
@@ -71,13 +71,14 @@ function cleanGaxiosConfig() {
 export interface SQLAdminFetcherOptions {
   loginAuth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
+  universeDomain?: string;
 }
 
 export class SQLAdminFetcher {
   private readonly client: sqladmin_v1beta4.Sqladmin;
   private readonly auth: GoogleAuth<AuthClient>;
 
-  constructor({loginAuth, sqlAdminAPIEndpoint}: SQLAdminFetcherOptions = {}) {
+  constructor({ loginAuth, sqlAdminAPIEndpoint, universeDomain }: SQLAdminFetcherOptions = {}) {
     let auth: GoogleAuth<AuthClient>;
 
     if (loginAuth instanceof GoogleAuth) {
@@ -98,6 +99,7 @@ export class SQLAdminFetcher {
           version: 'LIBRARY_SEMVER_VERSION',
         },
       ],
+      universeDomain: universeDomain,
     });
 
     if (loginAuth instanceof GoogleAuth) {
@@ -137,7 +139,7 @@ export class SQLAdminFetcher {
       res.data.dnsName
     );
 
-    const {serverCaCert} = res.data;
+    const { serverCaCert } = res.data;
     if (!serverCaCert || !serverCaCert.cert || !serverCaCert.expirationTime) {
       throw new CloudSQLConnectorError({
         message: 'Cannot connect to instance, no valid CA certificate found',
@@ -145,7 +147,7 @@ export class SQLAdminFetcher {
       });
     }
 
-    const {region} = res.data;
+    const { region } = res.data;
     if (!region) {
       throw new CloudSQLConnectorError({
         message: 'Cannot connect to instance, no valid region found',
@@ -171,7 +173,7 @@ export class SQLAdminFetcher {
   }
 
   async getEphemeralCertificate(
-    {projectId, instanceId}: InstanceConnectionInfo,
+    { projectId, instanceId }: InstanceConnectionInfo,
     publicKey: string,
     authType: AuthTypes
   ): Promise<SslCert> {
@@ -212,7 +214,7 @@ export class SQLAdminFetcher {
       });
     }
 
-    const {ephemeralCert} = res.data;
+    const { ephemeralCert } = res.data;
     if (!ephemeralCert || !ephemeralCert.cert) {
       throw new CloudSQLConnectorError({
         message:
@@ -223,7 +225,7 @@ export class SQLAdminFetcher {
 
     // NOTE: If the SQL Admin generateEphemeralCert API starts returning
     // the expirationTime info, this certificate parsing is no longer needed
-    const {cert, expirationTime} = await parseCert(ephemeralCert.cert);
+    const { cert, expirationTime } = await parseCert(ephemeralCert.cert);
 
     const nearestExpiration = getNearestExpiration(
       Date.parse(expirationTime),


### PR DESCRIPTION
In `googleapis-common` v7.1.0 a GlobalOption for `universeDomain` was added with the respective error handling for TPC support.

This gives the Node Connector support TPC by adding the `universeDomain` as a `ConnectorOptions`:

```js
import { Connector } from '@google-cloud/cloud-sql-connector';

const connector = new Connector({
    universeDomain: 'my-universe-domain'
});
```

Ref: https://github.com/googleapis/nodejs-googleapis-common/pull/548