### PR TITLE
ci: remove macos 14.x builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
         exclude:
           - os: windows-latest
             node-version: "v14.x"
+          - os: macos-latest
+            node-version: "v14.x"
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -149,6 +151,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
+            node-version: "v14.x"
+          - os: macos-latest
             node-version: "v14.x"
       fail-fast: false
     permissions:


### PR DESCRIPTION
It seems Github Actions is now only supporting Node 14 on Linux now, dropping macos as they had windows already.

Will leave ubuntu 14.x build as our sole 14.x build
