### PR TITLE
fix: enable IP type switching

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -77,15 +77,7 @@ class CloudSQLInstanceMap extends Map {
     // been setup there's no need to set it up again
     if (this.has(instanceConnectionName)) {
       const instance = this.get(instanceConnectionName);
-      if (instance.ipType && instance.ipType !== ipType) {
-        throw new CloudSQLConnectorError({
-          message:
-            `getOptions called for instance ${instanceConnectionName} with ipType ${ipType}, ` +
-            `but was previously called with ipType ${instance.ipType}. ` +
-            'If you require both for your use case, please use a new connector object.',
-          code: 'EMISMATCHIPTYPE',
-        });
-      } else if (instance.authType && instance.authType !== authType) {
+      if (instance.authType && instance.authType !== authType) {
         throw new CloudSQLConnectorError({
           message:
             `getOptions called for instance ${instanceConnectionName} with authType ${authType}, ` +
@@ -107,11 +99,9 @@ class CloudSQLInstanceMap extends Map {
 
   getInstance({
     instanceConnectionName,
-    ipType,
     authType,
   }: {
     instanceConnectionName: string;
-    ipType: IpAddressTypes;
     authType: AuthTypes;
   }): CloudSQLInstance {
     const connectionInstance = this.get(instanceConnectionName);
@@ -119,17 +109,6 @@ class CloudSQLInstanceMap extends Map {
       throw new CloudSQLConnectorError({
         message: `Cannot find info for instance: ${instanceConnectionName}`,
         code: 'ENOINSTANCEINFO',
-      });
-    } else if (
-      connectionInstance.ipType &&
-      connectionInstance.ipType !== ipType
-    ) {
-      throw new CloudSQLConnectorError({
-        message:
-          `getOptions called for instance ${instanceConnectionName} with ipType ${ipType}, ` +
-          `but was previously called with ipType ${connectionInstance.ipType}. ` +
-          'If you require both for your use case, please use a new connector object.',
-        code: 'EMISMATCHIPTYPE',
       });
     } else if (
       connectionInstance.authType &&

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -179,7 +179,6 @@ export class Connector {
       stream() {
         const cloudSqlInstance = instances.getInstance({
           instanceConnectionName,
-          ipType,
           authType,
         });
         const {


### PR DESCRIPTION
When the metadata of a Cloud SQL instance is fetched via the `connectSettings` API, the connector caches all IP addresses and types. Thus it has the information required to connect via either Public or Private IP. 

The Node Connector currently incorrectly errors when a user switches IP types between consecutive calls... this PR removes the incorrect erroring and allows for the following usage:

```js
import mysql from 'mysql2/promise';
import { Connector } from '@google-cloud/cloud-sql-connector';

const connector = new Connector();

// establish connection via Public IP
var clientOpts = await connector.getOptions({
    instanceConnectionName: 'my-project:us-central1:my-instance',
    ipType: 'PUBLIC',
});

const conn = await mysql.createConnection({
    ...clientOpts,
    user: 'root',
    password: 'my-password',
    database: 'my-database',
});

const [result] = await conn.query(`SELECT NOW();`);

// establish connection via Private IP
var clientOpts = await connector.getOptions({
    instanceConnectionName: 'my-project:us-central1:my-instance',
    ipType: 'PRIVATE',
});

const conn2 = await mysql.createConnection({
    ...clientOpts,
    user: 'root',
    password: 'my-password',
    database: 'my-database',
});
const [result2] = await conn.query(`SELECT NOW();`);

connector.close()
```

Fixes #305 