### PR TITLE
chore: automate updating devDependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,12 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "dependencies for github"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",       
+      "schedule": ["on monday", "after 1am and before 7am"]
     }
   ],
   "ignoreDeps": ["typescript"]


### PR DESCRIPTION
Currently `devDependencies` in package-lock.json are not being bumped by renovate. This PR changes that for them to be bumped once a week on Monday mornings.

Ref: https://github.com/renovatebot/renovate/discussions/15620

Closes #317 
Closes #190 