### PR TITLE
ci: skip int and sample tests from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,10 @@ jobs:
 
   system-tests:
     name: System tests
+    # run integration tests on all builds except pull requests from forks or dependabot
+    if: |
+      github.event_name != 'pull_request' || 
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         node-version: [v14.x, v16.x, v20.x]
@@ -265,6 +269,10 @@ jobs:
 
   sample-tests:
     name: Sample tests
+    # run sample tests on all builds except pull requests from forks or dependabot
+    if: |
+      github.event_name != 'pull_request' || 
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Pull request from forks once merged will still be skipped because `github.event.pull_request.head.repo.full_name` will still be that of the fork.

To combat this we run the job on all events that are not a pull_request (aka `schedule` and `push`)