### PR TITLE
feat: add support for custom user agent

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -148,6 +148,7 @@ interface ConnectorOptions {
    * Defaults to `googleapis.com`.
    */
   universeDomain?: string;
+  userAgent?: string;
 }
 
 // The Connector class is the main public API to interact
@@ -164,6 +165,7 @@ export class Connector {
       loginAuth: opts.auth,
       sqlAdminAPIEndpoint: opts.sqlAdminAPIEndpoint,
       universeDomain: opts.universeDomain,
+      userAgent: opts.userAgent,
     });
     this.localProxies = new Set();
     this.sockets = new Set();

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -174,7 +174,8 @@ export class SQLAdminFetcher {
       project: projectId,
       instance: instanceId,
     });
-
+    const userAgent = res.config.headers!['User-Agent'];
+    console.log('UserAgent: ', userAgent);
     if (!res.data) {
       throw new CloudSQLConnectorError({
         message:

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -175,6 +175,7 @@ export class SQLAdminFetcher {
       instance: instanceId,
     });
     const userAgent = res.config.headers!['User-Agent'];
+    console.warn('Printing user agent!!!');
     console.log('UserAgent: ', userAgent);
     if (!res.data) {
       throw new CloudSQLConnectorError({

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -82,6 +82,7 @@ export interface SQLAdminFetcherOptions {
   loginAuth?: GoogleAuth<AuthClient> | AuthClient;
   sqlAdminAPIEndpoint?: string;
   universeDomain?: string;
+  userAgent?: string;
 }
 
 export class SQLAdminFetcher {
@@ -92,6 +93,7 @@ export class SQLAdminFetcher {
     loginAuth,
     sqlAdminAPIEndpoint,
     universeDomain,
+    userAgent,
   }: SQLAdminFetcherOptions = {}) {
     let auth: GoogleAuth<AuthClient>;
 
@@ -111,6 +113,7 @@ export class SQLAdminFetcher {
         {
           product: 'cloud-sql-nodejs-connector',
           version: 'LIBRARY_SEMVER_VERSION',
+          comment: userAgent,
         },
       ],
       universeDomain: universeDomain,

--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -174,9 +174,7 @@ export class SQLAdminFetcher {
       project: projectId,
       instance: instanceId,
     });
-    const userAgent = res.config.headers!['User-Agent'];
-    console.warn('Printing user agent!!!');
-    console.log('UserAgent: ', userAgent);
+
     if (!res.data) {
       throw new CloudSQLConnectorError({
         message:

--- a/test/connector.ts
+++ b/test/connector.ts
@@ -545,3 +545,23 @@ t.test('Connector, custom universeDomain', async t => {
 
   t.same(actualUniverseDomain, expectedUniverseDomain);
 });
+
+t.test('Connector, custom userAgent', async t => {
+  const expectedUserAgent = 'custom-agent';
+  let actualUserAgent: string | undefined;
+  // mocks sql admin fetcher to check that the custom
+  // userAgent is correctly passed into it
+  const {Connector} = t.mockRequire('../src/connector', {
+    '../src/sqladmin-fetcher': {
+      SQLAdminFetcher: class {
+        constructor({userAgent}: SQLAdminFetcherOptions) {
+          actualUserAgent = userAgent;
+        }
+      },
+    },
+  });
+
+  new Connector({userAgent: expectedUserAgent});
+
+  t.same(actualUserAgent, expectedUserAgent);
+});


### PR DESCRIPTION
Add support for custom user agent via user agent comments.

HTTP user agent's take the form of `<product> / <product-version> <comment>`

Previously, we did not allow support for the `comment` field, leaving no way
to customize a user agent:
https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/blob/5bbd6be6692c8d82e8fb046fec889109e4778e7b/src/sqladmin-fetcher.ts#L110-L114

This PR changes that by adding `userAgent` as a supported `ConnectorOptions`
which will be passed and used to set the `comment` field, allowing customizations
to the user agent.

```js
const connector = new Connector({ userAgent: 'custom-agent'})
```

Closes: #401 
Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent