### PR TITLE
chore: Add domainName to instance configuration, part of #421.

### DIFF
--- a/src/dns-lookup.ts
+++ b/src/dns-lookup.ts
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import dns from 'node:dns';
+import {CloudSQLConnectorError} from './errors';
+
+export async function resolveTxtRecord(name: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    dns.resolveTxt(name, (err, addresses) => {
+      if (err) {
+        reject(
+          new CloudSQLConnectorError({
+            code: 'EDOMAINNAMELOOKUPERROR',
+            message: 'Error looking up TXT record for domain ' + name,
+            errors: [err],
+          })
+        );
+        return;
+      }
+
+      if (!addresses || addresses.length === 0) {
+        reject(
+          new CloudSQLConnectorError({
+            code: 'EDOMAINNAMELOOKUPFAILED',
+            message: 'No records returned for domain ' + name,
+          })
+        );
+        return;
+      }
+
+      // Each result may be split into multiple strings. Join the strings.
+      const joinedAddresses = addresses.map(strs => strs.join(''));
+      // Sort the results alphabetically for consistency,
+      joinedAddresses.sort((a, b) => a.localeCompare(b));
+      // Return the first result.
+      resolve(joinedAddresses[0]);
+    });
+  });
+}

--- a/src/instance-connection-info.ts
+++ b/src/instance-connection-info.ts
@@ -16,4 +16,5 @@ export interface InstanceConnectionInfo {
   projectId: string;
   regionId: string;
   instanceId: string;
+  domainName?: string;
 }

--- a/src/parse-instance-connection-name.ts
+++ b/src/parse-instance-connection-name.ts
@@ -14,6 +14,83 @@
 
 import {InstanceConnectionInfo} from './instance-connection-info';
 import {CloudSQLConnectorError} from './errors';
+import {resolveTxtRecord} from './dns-lookup';
+
+export function isSameInstance(
+  a: InstanceConnectionInfo,
+  b: InstanceConnectionInfo
+): boolean {
+  return (
+    a.instanceId === b.instanceId &&
+    a.regionId === b.regionId &&
+    a.projectId === b.projectId &&
+    a.domainName === b.domainName
+  );
+}
+
+export async function resolveInstanceName(
+  instanceConnectionName?: string,
+  domainName?: string
+): Promise<InstanceConnectionInfo> {
+  if (!instanceConnectionName && !domainName) {
+    throw new CloudSQLConnectorError({
+      message:
+        'Missing instance connection name, expected: "PROJECT:REGION:INSTANCE" or a valid domain name.',
+      code: 'ENOCONNECTIONNAME',
+    });
+  } else if (
+    instanceConnectionName &&
+    isInstanceConnectionName(instanceConnectionName)
+  ) {
+    return parseInstanceConnectionName(instanceConnectionName);
+  } else if (domainName && isValidDomainName(domainName)) {
+    return await resolveDomainName(domainName);
+  } else {
+    throw new CloudSQLConnectorError({
+      message:
+        'Malformed Instance connection name, expected an instance connection name in the form "PROJECT:REGION:INSTANCE" or a valid domain name',
+      code: 'EBADCONNECTIONNAME',
+    });
+  }
+}
+
+const connectionNameRegex =
+  /^(?<projectId>[^:]+(:[^:]+)?):(?<regionId>[^:]+):(?<instanceId>[^:]+)$/;
+
+// The domain name pattern in accordance with RFC 1035, RFC 1123 and RFC 2181.
+// From Go Connector:
+const domainNameRegex =
+  /^(?:[_a-z0-9](?:[_a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)?$/;
+
+export function isValidDomainName(name: string): boolean {
+  const matches = String(name).match(domainNameRegex);
+  return Boolean(matches);
+}
+
+export function isInstanceConnectionName(name: string): boolean {
+  const matches = String(name).match(connectionNameRegex);
+  return Boolean(matches);
+}
+
+export async function resolveDomainName(
+  name: string
+): Promise<InstanceConnectionInfo> {
+  const icn = await resolveTxtRecord(name);
+  if (!isInstanceConnectionName(icn)) {
+    throw new CloudSQLConnectorError({
+      message:
+        'Malformed instance connection name returned for domain ' +
+        name +
+        ' : ' +
+        icn,
+      code: 'EBADDOMAINCONNECTIONNAME',
+    });
+  }
+
+  const info = parseInstanceConnectionName(icn);
+  info.domainName = name;
+  return info;
+}
 
 export function parseInstanceConnectionName(
   instanceConnectionName: string | undefined
@@ -26,20 +103,8 @@ export function parseInstanceConnectionName(
     });
   }
 
-  const connectionNameRegex =
-    /(?<projectId>[^:]+(:[^:]+)?):(?<regionId>[^:]+):(?<instanceId>[^:]+)/;
   const matches = String(instanceConnectionName).match(connectionNameRegex);
-  if (!matches) {
-    throw new CloudSQLConnectorError({
-      message:
-        'Malformed instance connection name provided: expected format ' +
-        `of "PROJECT:REGION:INSTANCE", got ${instanceConnectionName}`,
-      code: 'EBADCONNECTIONNAME',
-    });
-  }
-
-  const unmatchedItems = matches[0] !== matches.input;
-  if (unmatchedItems || !matches.groups) {
+  if (!matches || !matches.groups) {
     throw new CloudSQLConnectorError({
       message:
         'Malformed instance connection name provided: expected format ' +
@@ -52,5 +117,6 @@ export function parseInstanceConnectionName(
     projectId: matches.groups.projectId,
     regionId: matches.groups.regionId,
     instanceId: matches.groups.instanceId,
+    domainName: undefined,
   };
 }

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -80,6 +80,7 @@ t.test('CloudSQLInstance', async t => {
         projectId: 'my-project',
         regionId: 'us-east1',
         instanceId: 'my-instance',
+        domainName: undefined,
       },
       'should have expected connection info'
     );

--- a/test/dns-lookup.ts
+++ b/test/dns-lookup.ts
@@ -1,0 +1,79 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import t from 'tap';
+
+t.test('lookup dns with mock responses', async t => {
+  const {resolveTxtRecord} = t.mockRequire('../src/dns-lookup.ts', {
+    'node:dns': {
+      resolveTxt: (name, callback) => {
+        switch (name) {
+          case 'db.example.com':
+            callback(null, [['my-project:region-1:instance']]);
+            return;
+          case 'multiple.example.com':
+            callback(null, [
+              ['my-project:region-1:instance'],
+              ['another-project:region-1:instance'],
+            ]);
+            return;
+          case 'split.example.com':
+            callback(null, [['my-project:', 'region-1:instance']]);
+            return;
+          case 'empty.example.com':
+            callback(null, []);
+            return;
+          default:
+            callback(new Error('not found'), null);
+            return;
+        }
+      },
+    },
+  });
+
+  t.same(
+    await resolveTxtRecord('db.example.com'),
+    'my-project:region-1:instance',
+    'valid domain name'
+  );
+  t.same(
+    await resolveTxtRecord('split.example.com'),
+    'my-project:region-1:instance',
+    'valid domain name'
+  );
+  t.same(
+    await resolveTxtRecord('multiple.example.com'),
+    'another-project:region-1:instance',
+    'valid domain name'
+  );
+  t.rejects(
+    async () => await resolveTxtRecord('not-found.example.com'),
+    {code: 'EDOMAINNAMELOOKUPERROR'},
+    'should throw type error if an extra item is provided'
+  );
+  t.rejects(
+    async () => await resolveTxtRecord('empty.example.com'),
+    {code: 'EDOMAINNAMELOOKUPFAILED'},
+    'should throw type error if an extra item is provided'
+  );
+});
+
+t.test('lookup dns with real responses', async t => {
+  const {resolveTxtRecord} = t.mockRequire('../src/dns-lookup.ts', {});
+  t.same(
+    await resolveTxtRecord('valid-san-test.csqlconnectortest.com'),
+    'cloud-sql-connector-testing:us-central1:postgres-customer-cas-test',
+    'valid domain name'
+  );
+});

--- a/test/parse-instance-connection-name.ts
+++ b/test/parse-instance-connection-name.ts
@@ -13,74 +13,359 @@
 // limitations under the License.
 
 import t from 'tap';
-import {parseInstanceConnectionName} from '../src/parse-instance-connection-name';
+import {
+  parseInstanceConnectionName,
+  isValidDomainName,
+  isInstanceConnectionName,
+  isSameInstance,
+} from '../src/parse-instance-connection-name';
 
-t.throws(
-  () => parseInstanceConnectionName(undefined),
-  {code: 'ENOCONNECTIONNAME'},
-  'should throw type error if no instance connection name provided'
-);
+import {CloudSQLConnectorError} from '../src/errors';
 
-t.throws(
-  () => parseInstanceConnectionName(''),
-  {code: 'ENOCONNECTIONNAME'},
-  'should throw type error if empty instance connection name provided'
-);
+t.test('parseInstanceConnectionname', async t => {
+  t.throws(
+    () => parseInstanceConnectionName(undefined),
+    {code: 'ENOCONNECTIONNAME'},
+    'should throw type error if no instance connection name provided'
+  );
 
-t.throws(
-  () => parseInstanceConnectionName('my-project:my-instance'),
-  {
-    code: 'EBADCONNECTIONNAME',
-    message:
-      'Malformed instance connection name provided: expected format ' +
-      'of "PROJECT:REGION:INSTANCE", got my-project:my-instance',
-  },
-  'should throw type error if malformed instance connection name provided'
-);
+  t.throws(
+    () => parseInstanceConnectionName(''),
+    {code: 'ENOCONNECTIONNAME'},
+    'should throw type error if empty instance connection name provided'
+  );
 
-t.throws(
-  () => parseInstanceConnectionName(':region-1:my-instance'),
-  {code: 'EBADCONNECTIONNAME'},
-  'should throw type error if missing project id'
-);
+  t.throws(
+    () => parseInstanceConnectionName('my-project:my-instance'),
+    {
+      code: 'EBADCONNECTIONNAME',
+    },
+    'should throw type error if malformed instance connection name provided'
+  );
 
-t.throws(
-  () => parseInstanceConnectionName('my-project::my-instance'),
-  {code: 'EBADCONNECTIONNAME'},
-  'should throw type error if missing region id'
-);
+  t.throws(
+    () => parseInstanceConnectionName(':region-1:my-instance'),
+    {code: 'EBADCONNECTIONNAME'},
+    'should throw type error if missing project id'
+  );
 
-t.throws(
-  () => parseInstanceConnectionName('my-project:region-1:'),
-  {code: 'EBADCONNECTIONNAME'},
-  'should throw type error if missing instance id'
-);
+  t.throws(
+    () => parseInstanceConnectionName('my-project::my-instance'),
+    {code: 'EBADCONNECTIONNAME'},
+    'should throw type error if missing region id'
+  );
 
-t.throws(
-  () =>
-    parseInstanceConnectionName(
-      'google.com:PROJECT:region-02:my-instance:extra-item'
-    ),
-  {code: 'EBADCONNECTIONNAME'},
-  'should throw type error if an extra item is provided'
-);
+  t.throws(
+    () => parseInstanceConnectionName('my-project:region-1:'),
+    {code: 'EBADCONNECTIONNAME'},
+    'should throw type error if missing instance id'
+  );
 
-t.same(
-  parseInstanceConnectionName('my-project:region-1:my-instance'),
-  {
-    projectId: 'my-project',
-    regionId: 'region-1',
-    instanceId: 'my-instance',
-  },
-  'should be able to parse standard data'
-);
+  t.throws(
+    () =>
+      parseInstanceConnectionName(
+        'google.com:PROJECT:region-02:my-instance:extra-item'
+      ),
+    {code: 'EBADCONNECTIONNAME'},
+    'should throw type error if an extra item is provided'
+  );
 
-t.same(
-  parseInstanceConnectionName('google.com:PROJECT:region-02:my-instance'),
-  {
-    projectId: 'google.com:PROJECT',
-    regionId: 'region-02',
-    instanceId: 'my-instance',
-  },
-  'should support legacy domain scoped project id'
-);
+  t.same(
+    parseInstanceConnectionName('my-project:region-1:my-instance'),
+    {
+      projectId: 'my-project',
+      regionId: 'region-1',
+      instanceId: 'my-instance',
+      domainName: undefined,
+    },
+    'should be able to parse standard data'
+  );
+
+  t.same(
+    parseInstanceConnectionName('google.com:PROJECT:region-02:my-instance'),
+    {
+      projectId: 'google.com:PROJECT',
+      regionId: 'region-02',
+      instanceId: 'my-instance',
+      domainName: undefined,
+    },
+    'should support legacy domain scoped project id'
+  );
+});
+
+t.test('isValidDomainName', async t => {
+  const tcs = [
+    {
+      domain: 'prod-db.mycompany.example.com',
+      want: true,
+    },
+    {
+      domain: 'example.com.', // trailing dot
+      want: true,
+    },
+    {
+      domain: '-example.com', // leading hyphen
+      want: false,
+    },
+    {
+      domain: 'example', // missing TLD
+      want: false,
+    },
+    {
+      domain: '127.0.0.1', // IPv4 address
+      want: false,
+    },
+    {
+      domain: '0:0:0:0:0:0:0:1', // IPv6 address
+      want: false,
+    },
+  ];
+  for (const tc of tcs) {
+    t.same(
+      isValidDomainName(tc.domain),
+      tc.want,
+      'validate domain ' + tc.domain
+    );
+  }
+});
+
+t.test('isInstanceConnectionName', async t => {
+  t.same(
+    isInstanceConnectionName('my-project:region-1:my-instance'),
+    true,
+    'invalid domain name'
+  );
+
+  t.same(
+    isInstanceConnectionName('project.example.com'),
+    false,
+    'should validate domain name'
+  );
+});
+
+t.test('resolveDomainName Mock DNS', async t => {
+  // mocks crypto module so that it can return a deterministic result
+  // and set a standard, fast static value for cert refresh interval
+  const {resolveDomainName} = t.mockRequire(
+    '../src/parse-instance-connection-name',
+    {
+      '../src/dns-lookup': {
+        resolveTxtRecord: async name => {
+          switch (name) {
+            case 'db.example.com':
+              return 'my-project:region-1:my-instance';
+            case 'bad.example.com':
+              return 'bad-instance-name';
+            default:
+              throw new CloudSQLConnectorError({
+                code: 'EDOMAINNAMELOOKUPERROR',
+                message: 'Error looking up TXT record for domain ' + name,
+              });
+          }
+        },
+      },
+    }
+  );
+
+  t.same(
+    await resolveDomainName('db.example.com'),
+    {
+      projectId: 'my-project',
+      regionId: 'region-1',
+      instanceId: 'my-instance',
+      domainName: 'db.example.com',
+    },
+    'should validate domain name'
+  );
+
+  await t.rejects(
+    async () => await resolveDomainName('bad.example.com'),
+    {code: 'EBADDOMAINCONNECTIONNAME'},
+    'should throw type error if an extra item is provided'
+  );
+
+  await t.rejects(
+    async () => await resolveDomainName('no-record.example.com'),
+    {code: 'EDOMAINNAMELOOKUPERROR'},
+    'should throw type error if an extra item is provided'
+  );
+});
+
+t.test('resolveInstanceName Mock DNS', async t => {
+  // mocks crypto module so that it can return a deterministic result
+  // and set a standard, fast static value for cert refresh interval
+  const {resolveInstanceName} = t.mockRequire(
+    '../src/parse-instance-connection-name',
+    {
+      '../src/dns-lookup': {
+        resolveTxtRecord: async name => {
+          switch (name) {
+            case 'db.example.com':
+              return 'my-project:region-1:my-instance';
+            case 'bad.example.com':
+              return 'bad-instance-name';
+            default:
+              throw new CloudSQLConnectorError({
+                code: 'EDOMAINNAMELOOKUPERROR',
+                message: 'Error looking up TXT record for domain ' + name,
+              });
+          }
+        },
+      },
+    }
+  );
+
+  t.same(
+    await resolveInstanceName(undefined, 'db.example.com'),
+    {
+      projectId: 'my-project',
+      regionId: 'region-1',
+      instanceId: 'my-instance',
+      domainName: 'db.example.com',
+    },
+    'should use domain name'
+  );
+
+  t.same(
+    await resolveInstanceName('my-project:region-1:my-instance'),
+    {
+      projectId: 'my-project',
+      regionId: 'region-1',
+      instanceId: 'my-instance',
+      domainName: undefined,
+    },
+    'should use instance name'
+  );
+
+  await t.rejects(
+    resolveInstanceName(undefined, 'bad.example.com'),
+    {code: 'EBADDOMAINCONNECTIONNAME'},
+    'should throw type error if an extra item is provided'
+  );
+
+  await t.rejects(
+    resolveInstanceName(undefined, 'no-record.example.com'),
+    {code: 'EDOMAINNAMELOOKUPERROR'},
+    'should throw type error if an extra item is provided'
+  );
+
+  await t.rejects(
+    resolveInstanceName(undefined, ''),
+    {code: 'ENOCONNECTIONNAME'},
+    'should throw type error if the connection name is empty'
+  );
+
+  await t.rejects(
+    resolveInstanceName(undefined, 'bad-name'),
+    {code: 'EBADCONNECTIONNAME'},
+    'should throw type error if the connection name is empty'
+  );
+});
+
+t.test('isSameInstance', async t => {
+  const tcs = [
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+        domainName: 'db1.example.com',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+        domainName: 'db1.example.com',
+      },
+      want: true,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      want: true,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      b: {
+        instanceId: 'inst2',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      want: false,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region2',
+        projectId: 'project1',
+      },
+      want: false,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project2',
+      },
+      want: false,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+        domainName: 'db1.example.com',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+      },
+      want: false,
+    },
+    {
+      a: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+        domainName: 'db1.example.com',
+      },
+      b: {
+        instanceId: 'inst',
+        regionId: 'region1',
+        projectId: 'project1',
+        domainName: 'db2.example.com',
+      },
+      want: false,
+    },
+  ];
+  for (const tc of tcs) {
+    t.same(
+      isSameInstance(tc.a, tc.b),
+      tc.want,
+      'is same instance ' + JSON.stringify(tc.a) + ' == ' + JSON.stringify(tc.b)
+    );
+  }
+});


### PR DESCRIPTION
Update `InstanceConnectionName` and `parseInstanceConnectionName()` to allow DNS names 
as well as instance connection names. Add test cases to cover DNS Names. Add new dns-lookup.ts
that looks up the instance connection name from a DNS name using the TXT record.

Part of #421