### PR TITLE
feat: Use standard TLS hostname validation for instances with DNS names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@googleapis/sqladmin": "^24.0.0",
+        "@googleapis/sqladmin": "^27.0.0",
         "gaxios": "^6.1.1",
         "google-auth-library": "^9.2.0",
         "p-throttle": "^7.0.0"
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@googleapis/sqladmin": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-24.0.0.tgz",
-      "integrity": "sha512-Sj2MerYrr4Z6ksK81Scj0gIdFjC3bC0vcqdM+TSfnOskg6d9iIALWdFDc3xgNHQWO58rUb6HjBzr1XbuNjYlPg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-27.0.0.tgz",
+      "integrity": "sha512-zXdM1zg+X/r/QM8Rl3sxI/7dk4mcwCegqiNCEeBfP7E07kNl1bLW767mp1VgfY8mN8HJRrQ8JEBeDRUWfO1iLg==",
       "dependencies": {
         "googleapis-common": "^7.0.0"
       },
@@ -12077,9 +12077,9 @@
       "peer": true
     },
     "@googleapis/sqladmin": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-24.0.0.tgz",
-      "integrity": "sha512-Sj2MerYrr4Z6ksK81Scj0gIdFjC3bC0vcqdM+TSfnOskg6d9iIALWdFDc3xgNHQWO58rUb6HjBzr1XbuNjYlPg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-27.0.0.tgz",
+      "integrity": "sha512-zXdM1zg+X/r/QM8Rl3sxI/7dk4mcwCegqiNCEeBfP7E07kNl1bLW767mp1VgfY8mN8HJRrQ8JEBeDRUWfO1iLg==",
       "requires": {
         "googleapis-common": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "url": "git+https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector"
   },
   "dependencies": {
-    "@googleapis/sqladmin": "^24.0.0",
+    "@googleapis/sqladmin": "^27.0.0",
     "gaxios": "^6.1.1",
     "google-auth-library": "^9.2.0",
     "p-throttle": "^7.0.0"

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -232,7 +232,6 @@ export class Connector {
           port,
           privateKey,
           serverCaCert,
-          serverCaMode,
           dnsName,
         } = cloudSqlInstance;
 
@@ -251,8 +250,8 @@ export class Connector {
             port,
             privateKey,
             serverCaCert,
-            serverCaMode,
-            dnsName: instanceInfo.domainName || dnsName, // use the configured domain name, or the instance dnsName.
+            instanceDnsName: dnsName,
+            serverName: instanceInfo.domainName || dnsName, // use the configured domain name, or the instance dnsName.
           });
           tlsSocket.once('error', () => {
             cloudSqlInstance.forceRefresh();

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -26,17 +26,17 @@ interface SocketOptions {
   instanceInfo: InstanceConnectionInfo;
   privateKey: string;
   serverCaCert: SslCert;
-  serverCaMode: string;
-  dnsName: string;
+  instanceDnsName: string;
+  serverName: string;
 }
 
 export function validateCertificate(
   instanceInfo: InstanceConnectionInfo,
-  serverCaMode: string,
-  dnsName: string
+  instanceDnsName: string,
+  serverName: string
 ) {
   return (hostname: string, cert: tls.PeerCertificate): Error | undefined => {
-    if (!serverCaMode || serverCaMode === 'GOOGLE_MANAGED_INTERNAL_CA') {
+    if (!instanceDnsName) {
       // Legacy CA Mode
       if (!cert || !cert.subject) {
         return new CloudSQLConnectorError({
@@ -54,7 +54,7 @@ export function validateCertificate(
       return undefined;
     } else {
       // Standard TLS Verify Full hostname verification using SAN
-      return tls.checkServerIdentity(dnsName, cert);
+      return tls.checkServerIdentity(serverName, cert);
     }
   };
 }
@@ -66,8 +66,8 @@ export function getSocket({
   instanceInfo,
   privateKey,
   serverCaCert,
-  serverCaMode,
-  dnsName,
+  instanceDnsName,
+  serverName,
 }: SocketOptions): tls.TLSSocket {
   const socketOpts = {
     host,
@@ -80,8 +80,8 @@ export function getSocket({
     }),
     checkServerIdentity: validateCertificate(
       instanceInfo,
-      serverCaMode,
-      dnsName
+      instanceDnsName,
+      serverName
     ),
   };
   const tlsSocket = tls.connect(socketOpts);

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -69,7 +69,7 @@ t.test('validateCertificate no cert', async t => {
         regionId: 'region-id',
         instanceId: 'my-instance',
       },
-      'GOOGLE_MANAGED_INTERNAL_CA',
+      null,
       'abcde.12345.us-central1.sql.goog'
     )('hostname', {} as tls.PeerCertificate),
     {code: 'ENOSQLADMINVERIFYCERT'},
@@ -90,7 +90,7 @@ t.test('validateCertificate mismatch', async t => {
         regionId: 'region-id',
         instanceId: 'my-instance',
       },
-      'GOOGLE_MANAGED_INTERNAL_CA',
+      null,
       'abcde.12345.us-central1.sql.goog'
     )('hostname', cert),
     {

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -16,6 +16,8 @@ import t from 'tap';
 import {InstanceConnectionInfo} from '../src/instance-connection-info';
 import {CLIENT_CERT} from './fixtures/certs';
 import {AuthTypes} from '../src/auth-types';
+import {sqladmin_v1beta4} from '@googleapis/sqladmin';
+import Schema$DnsNameMapping = sqladmin_v1beta4.Schema$DnsNameMapping;
 
 // Mocks the @googleapis/sqladmin interface
 interface SQLAdminOptions {
@@ -27,6 +29,7 @@ interface IpAddress {
 }
 interface SQLAdminClientGetResponse {
   dnsName?: string;
+  dnsNames?: Schema$DnsNameMapping[];
   ipAddresses?: IpAddress[];
   pscEnabled?: boolean;
   region?: string;
@@ -98,7 +101,13 @@ const mockSQLAdminGetInstanceMetadata = (
 
   sqlAdminClient.get = () => ({
     data: {
-      dnsName: 'abcde.12345.us-central1.sql.goog',
+      dnsNames: [
+        {
+          name: 'abcde.12345.us-central1.sql.goog',
+          connectionType: 'PRIVATE_SERVICE_CONNECT',
+          dnsScope: 'INSTANCE',
+        },
+      ],
       ipAddresses: [
         {
           type: 'PRIMARY',
@@ -216,6 +225,7 @@ t.test('getInstanceMetadata no ip', async t => {
   };
   mockSQLAdminGetInstanceMetadata(instanceConnectionInfo, {
     dnsName: 'abcde.12345.us-central1.sql.goog',
+    dnsNames: null,
     ipAddresses: [],
     pscEnabled: false,
   });


### PR DESCRIPTION
When the the Cloud SQL Instance reports that it has a DNS Name, the connector will use standard TLS hostname validation when checking the server certificate. Now, the server's TLS certificate must contain a SAN record with the instance's DNS name.

The ConnectSettings API added a field dns_names which contains all of the valid DNS names for
an instance.

See also: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/954