### PR TITLE
ci: add cloudbuild config for PSA tests 

### DIFF
--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -1,0 +1,78 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: run integration tests
+    name: node:${_VERSION}
+    entrypoint: bash
+    env:
+      - "IP_TYPE=${_IP_TYPE}"
+    secretEnv: ['MYSQL_CONNECTION_NAME', 'MYSQL_USER', 'MYSQL_IAM_USER', 'MYSQL_PASS', 'MYSQL_DB', 'POSTGRES_CONNECTION_NAME', 'POSTGRES_USER', 'POSTGRES_IAM_USER', 'POSTGRES_PASS', 'POSTGRES_DB', 'POSTGRES_CAS_CONNECTION_NAME', 'POSTGRES_CAS_PASS', 'POSTGRES_CUSTOMER_CAS_CONNECTION_NAME', 'POSTGRES_CUSTOMER_CAS_PASS', 'POSTGRES_CUSTOMER_CAS_DOMAIN_NAME', 'POSTGRES_CUSTOMER_CAS_INVALID_DOMAIN_NAME', 'SQLSERVER_CONNECTION_NAME', 'SQLSERVER_USER', 'SQLSERVER_PASS', 'SQLSERVER_DB']
+    args:
+      - "-c"
+      - |
+        npm link
+        npm link @google-cloud/cloud-sql-connector
+        npx tap -c -t0 --disable-coverage --allow-empty-coverage system-test -o test_results.tap
+    timeout: 300s
+availableSecrets:
+  secretManager:
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_CONNECTION_NAME/versions/latest'
+    env: 'MYSQL_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_USER/versions/latest'
+    env: 'MYSQL_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/CLOUD_BUILD_MYSQL_IAM_USER/versions/latest'
+    env: 'MYSQL_IAM_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_PASS/versions/latest'
+    env: 'MYSQL_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_DB/versions/latest'
+    env: 'MYSQL_DB'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_USER/versions/latest'
+    env: 'POSTGRES_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/CLOUD_BUILD_POSTGRES_IAM_USER/versions/latest'
+    env: 'POSTGRES_IAM_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_PASS/versions/latest'
+    env: 'POSTGRES_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_DB/versions/latest'
+    env: 'POSTGRES_DB'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CAS_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CAS_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CAS_PASS/versions/latest'
+    env: 'POSTGRES_CAS_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_PASS/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_DOMAIN_NAME/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_DOMAIN_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_INVALID_DOMAIN_NAME/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_INVALID_DOMAIN_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_CONNECTION_NAME/versions/latest'
+    env: 'SQLSERVER_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_USER/versions/latest'
+    env: 'SQLSERVER_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_PASS/versions/latest'
+    env: 'SQLSERVER_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_DB/versions/latest'
+    env: 'SQLSERVER_DB'
+substitutions:
+  _VERSION: ${_VERSION}
+  _IP_TYPE: ${_IP_TYPE}
+options:
+  dynamicSubstitutions: true
+  pool:
+    name: ${_POOL_NAME}
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This PR enables private IP tests for Cloud SQL instances with the help of Cloud Build private pool

Introduced a new environment variable - IP_TYPE which is set as "PRIVATE" for PSA tests in the cloudbuild.yaml file

Before reviewing this PR, please review: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/pull/433
