### PR TITLE
fix: Report the error when module node:crypto throws an error during import.

### DIFF
--- a/src/node-crypto.ts
+++ b/src/node-crypto.ts
@@ -22,10 +22,17 @@ export async function cryptoModule(): Promise<Crypto> {
   try {
     crypto = await import('node:crypto');
     /* c8 ignore next 6 */
-  } catch (err) {
+  } catch (err: unknown) {
+    let error: Error;
+    if (err instanceof Error) {
+      error = err;
+    } else {
+      error = new Error(String(err));
+    }
     throw new CloudSQLConnectorError({
       message: 'Support to node crypto module is required',
       code: 'ENOCRYPTOMODULE',
+      errors: [error],
     });
   }
   return crypto;


### PR DESCRIPTION
Report the underlying error that occurs when importing the `node:crypto` module. This will help
identify the reason that the node:crypto module cannot be imported.

Related to #435