### PR TITLE
feat: Update TLS validation to use both SAN and CN fields.

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -30,33 +30,90 @@ interface SocketOptions {
   serverName: string;
 }
 
+/**
+ * validateCertificate implements custom TLS verification logic to gracefully and securely
+ * handle deviations from standard TLS hostname verification in existing Cloud SQL instance server
+ * certificates.
+ *
+ *
+ * @param instanceInfo the instance connection name
+ * @param instanceDnsName the instance's DNS name according to instance metadata
+ * @param serverName the dns name from the connector configuration.
+ *
+ * This is run AFTER the NodeJS TLS library has validated the CA for the
+ * server certificate.
+ *
+ * <p>This is the verification algorithm:
+ *
+ * <ol>
+ *   <li>Verify the server cert CA, using the CA certs from the instance metadata. Reject the
+ *       certificate if the CA is invalid.
+ *   <li>Check that the server cert contains a SubjectAlternativeName matching the DNS name in the
+ *       connector configuration OR the DNS Name from the instance metadata
+ *   <li>If the SubjectAlternativeName does not match, and if the server cert Subject.CN field is
+ *       not empty, check that the Subject.CN field contains the instance name. Reject the
+ *       certificate if both the #2 SAN check and #3 CN checks fail.
+ * </ol>
+ *
+ * <p>To summarize the deviations from standard TLS hostname verification:
+ *
+ * <p>Historically, Cloud SQL creates server certificates with the instance name in the Subject.CN
+ * field in the format "my-project:my-instance". The connector is expected to check that the
+ * instance name that the connector was configured to dial matches the server certificate Subject.CN
+ * field. Thus, the Subject.CN field for most Cloud SQL instances does not contain a well-formed DNS
+ * Name. This breaks standard TLS hostname verification.
+ *
+ * <p>Also, there are times when the instance metadata reports that an instance has a DNS name, but
+ * that DNS name does not yet appear in the SAN records of the server certificate. The client should
+ * fall back to validating the hostname using the instance name in the Subject.CN field.
+ */
 export function validateCertificate(
   instanceInfo: InstanceConnectionInfo,
   instanceDnsName: string,
   serverName: string
 ) {
   return (hostname: string, cert: tls.PeerCertificate): Error | undefined => {
-    if (!instanceDnsName) {
-      // Legacy CA Mode
-      if (!cert || !cert.subject) {
-        return new CloudSQLConnectorError({
-          message: 'No certificate to verify',
-          code: 'ENOSQLADMINVERIFYCERT',
-        });
-      }
-      const expectedCN = `${instanceInfo.projectId}:${instanceInfo.instanceId}`;
-      if (cert.subject.CN !== expectedCN) {
-        return new CloudSQLConnectorError({
-          message: `Certificate had CN ${cert.subject.CN}, expected ${expectedCN}`,
-          code: 'EBADSQLADMINVERIFYCERT',
-        });
-      }
-      return undefined;
-    } else {
-      // Standard TLS Verify Full hostname verification using SAN
-      return tls.checkServerIdentity(serverName, cert);
+    if (!cert) {
+      return new CloudSQLConnectorError({
+        message: 'Certificate missing',
+        code: 'ENOSQLADMINVERIFYCERT',
+      });
     }
+
+    if (!instanceDnsName) {
+      return checkCn(instanceInfo, cert);
+    } else {
+      const err = tls.checkServerIdentity(serverName, cert);
+      if (err) {
+        const cnErr = checkCn(instanceInfo, cert);
+        if (cnErr) {
+          return err;
+        }
+      }
+    }
+
+    return undefined;
   };
+}
+
+function checkCn(
+  instanceInfo: InstanceConnectionInfo,
+  cert: tls.PeerCertificate
+) {
+  const expectedCN = `${instanceInfo.projectId}:${instanceInfo.instanceId}`;
+  if (!cert.subject || !cert.subject.CN) {
+    return new CloudSQLConnectorError({
+      message: `Certificate missing CN, expected ${expectedCN}`,
+      code: 'ENOSQLADMINVERIFYCERT',
+    });
+  }
+  if (cert.subject.CN && cert.subject.CN !== expectedCN) {
+    return new CloudSQLConnectorError({
+      message: `Certificate had CN ${cert.subject.CN}, expected ${expectedCN}`,
+      code: 'EBADSQLADMINVERIFYCERT',
+    });
+  }
+  return undefined;
 }
 
 export function getSocket({
@@ -78,6 +135,8 @@ export function getSocket({
       key: privateKey,
       minVersion: 'TLSv1.3',
     }),
+    // This checks the provided serverName against the server certificate. It
+    // is called after the TLS CA chain of is validated.
     checkServerIdentity: validateCertificate(
       instanceInfo,
       instanceDnsName,


### PR DESCRIPTION
This updates the logic used by the connector to validate server certificates.
When connecting to the instance, the connector's TLS validator will first check the SAN field,
and then if that fails check the CN field in the certificate for the instance name. This will enable
the connector to work smoothly with both legacy and newer instances.

To summarize the deviations from standard TLS hostname verification:

Historically, Cloud SQL creates server certificates with the instance name in the Subject.CN field in 
the format "my-project:my-instance". The connector is expected to check that the instance name
that the connector was configured to dial matches the server certificate Subject.CN field. Thus, 
the Subject.CN field for most Cloud SQL instances does not contain a well-formed DNS Name. This
breaks standard TLS hostname verification.

Also, there are times when the instance metadata reports that an instance has a DNS name, but
that DNS name does not yet appear in the SAN records of the server certificate. The client should
fall back to validating the hostname using the instance name in the Subject.CN field.

See also: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/979