### PR TITLE
fix: connector close leaks for in-flight queries

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -364,12 +364,14 @@ export class CloudSQLInstance {
       this.checkDomainID = null;
     }
     for (const socket of this.sockets) {
-      socket.destroy(
-        new CloudSQLConnectorError({
-          code: 'ERRCLOSED',
-          message: 'The connector was closed.',
-        })
-      );
+      if (typeof socket.destroy === 'function') {
+        socket.destroy(
+          new CloudSQLConnectorError({
+            code: 'ERRCLOSED',
+            message: 'The connector was closed.',
+          })
+        );
+      }
     }
   }
 
@@ -391,15 +393,15 @@ export class CloudSQLInstance {
     }
   }
   addSocket(socket: DestroyableSocket) {
-    if (!this.instanceInfo.domainName) {
-      // This was not connected by domain name. Ignore all sockets.
-      return;
-    }
-
-    // Add the socket to the list
+    // Track all active sockets created by this instance so they can
+    // be forcefully cleaned up during a domain change or when
+    // the connector is explicitly closed.
     this.sockets.add(socket);
-    // When the socket is closed, remove it.
-    socket.once('closed', () => {
+
+    // When the socket is closed by the driver or peer, remove it
+    // from our tracking set to prevent reference memory leaks.
+    // Note: Node.js TLSSocket/Socket emits 'close', not 'closed'.
+    socket.once('close', () => {
       this.sockets.delete(socket);
     });
   }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -358,8 +358,17 @@ export class Connector {
   //
   // Also clear up any local proxy servers and socket connections.
   close(): void {
-    for (const instance of this.instances.values()) {
-      instance.promise.then(inst => inst.close());
+    for (const entry of this.instances.values()) {
+      if (entry.isResolved() && entry.instance) {
+        // If the instance is already resolved, close it synchronously.
+        // This prevents a race condition with immediate connection pool close
+        // (e.g., pool.end()) where asynchronous microtasks would execute too late.
+        entry.instance.close();
+      } else {
+        // Otherwise, close the instance asynchronously once its initial
+        // refresh has finished.
+        entry.promise.then(inst => inst.close()).catch(() => {});
+      }
     }
     for (const server of this.localProxies) {
       server.close();


### PR DESCRIPTION
## Change Description

## Problem
When a Node.js process receives a termination signal (e.g., SIGTERM), typical graceful shutdown sequences call await pool.end() followed by connector.close(). However, as reported in #562, if there are active database queries mid-flight when shutdown begins, the TLS sockets remain alive in the event loop indefinitely, preventing the Node.js process from exiting cleanly.


### There were three root causes contributing to this leak:

- **Ignored Sockets:** CloudSQLInstance.addSocket explicitly ignored sockets unless they connected via custom domain name routing (if (!this.instanceInfo.domainName) return;). Standard connections using an instance connection name were never tracked.
- **Asynchronous Cleanup Race:** Connector.close() resolved instance closure asynchronously in the promise microtask queue (instance.promise.then(inst => inst.close())). This ran too late, racing with database pool closures and failing to terminate active network handles synchronously.
- **Incorrect Socket Event Listener:** The connector registered a listener for the non-existent 'closed' socket event (socket.once('closed', ...)) instead of the standard Node.js 'close' event. As a result, sockets were never pruned from the tracking set even when closed normally, causing a silent reference memory leak.


## Solution
This PR resolves the socket leaks and ensures clean shutdown of standard connection pools:

1. Universal Socket Tracking: Removed the domainName guard clause in CloudSQLInstance.addSocket to track all active TLS sockets regardless of the connection route.
2. Synchronous Instance Teardown: Updated Connector.close() to check if a cached instance is already resolved (entry.isResolved()) and close it synchronously. Unresolved instances fall back safely to asynchronous promise resolution.
3. Correct Socket Close Event: Updated the cleanup event listener to hook into Node's 'close' event, ensuring that normally terminated sockets are properly pruned from the internal set.
4. Safe Stream Teardown: Added a check to ensure socket.destroy exists and is a function before calling it, maintaining backward compatibility with mock socket streams used in some test environments.

## Checklist

- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #<issue_number_goes_here>
