### PR TITLE
fix: close sockets without synthetic error

### DIFF
--- a/src/cloud-sql-instance.ts
+++ b/src/cloud-sql-instance.ts
@@ -25,7 +25,6 @@ import {RSAKeys} from './rsa-keys';
 import {SslCert} from './ssl-cert';
 import {getRefreshInterval, isExpirationTimeValid} from './time';
 import {AuthTypes} from './auth-types';
-import {CloudSQLConnectorError} from './errors';
 
 // Private types that describe exactly the methods
 // needed from tls.Socket to be able to close
@@ -364,12 +363,9 @@ export class CloudSQLInstance {
       this.checkDomainID = null;
     }
     for (const socket of this.sockets) {
-      socket.destroy(
-        new CloudSQLConnectorError({
-          code: 'ERRCLOSED',
-          message: 'The connector was closed.',
-        })
-      );
+      if (typeof socket.destroy === 'function') {
+        socket.destroy();
+      }
     }
   }
 

--- a/test/cloud-sql-instance.ts
+++ b/test/cloud-sql-instance.ts
@@ -552,6 +552,40 @@ t.test('CloudSQLInstance', async t => {
     }
   );
 
+  t.test('close destroys tracked sockets without an error', async t => {
+    const instance = new CloudSQLInstance({
+      options: {
+        ipType: IpAddressTypes.PUBLIC,
+        authType: AuthTypes.PASSWORD,
+        instanceConnectionName: 'my-project:us-east1:my-instance',
+        sqlAdminFetcher: fetcher,
+      },
+      instanceInfo: {
+        projectId: 'my-project',
+        regionId: 'us-east1',
+        instanceId: 'my-instance',
+        domainName: 'my-instance.example.com',
+      },
+    });
+
+    const destroyArgs: Array<Error | undefined> = [];
+    const socket = {
+      destroy(error?: Error) {
+        destroyArgs.push(error);
+      },
+      once() {},
+    };
+
+    instance.addSocket(socket);
+    instance.close();
+
+    t.same(
+      destroyArgs,
+      [undefined],
+      'close should not emit a synthetic socket error'
+    );
+  });
+
   t.test(
     'get invalid certificate data while having a current valid',
     async t => {


### PR DESCRIPTION
## Change Description

Fixes #576.

`CloudSQLInstance.close()` still destroys every tracked socket so shutdown can clean up active handles, but it no longer passes a synthetic `CloudSQLConnectorError` into `socket.destroy()`. Passing that error causes Node to emit an asynchronous socket `error` event; after drivers such as `pg` have drained a pool and removed socket listeners, that event can become an uncaught exception during intentional connector shutdown.

The added unit test verifies close-time socket teardown calls `destroy()` without an error argument.

## Checklist

- [x] Make sure to open an issue as a bug/issue before writing your code
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (not necessary)

## Validation

- `npx tap -t0 -c test/cloud-sql-instance.ts`
- `npm run lint`
- `npm run compile`
- `npm test`
