### PR TITLE
fix: prioritize PSC auto-DNS names (.sql-psc.goog) and trim trailing dots

### DIFF
--- a/src/sqladmin-fetcher.ts
+++ b/src/sqladmin-fetcher.ts
@@ -155,21 +155,35 @@ export class SQLAdminFetcher {
 
     // Search the dns_names field for the PSC DNS Name.
     if (dnsNames) {
+      const pscDnsNames: string[] = [];
       for (const dnm of dnsNames) {
         if (
           dnm.name &&
           dnm.connectionType === 'PRIVATE_SERVICE_CONNECT' &&
           dnm.dnsScope === 'INSTANCE'
         ) {
-          ipAddresses.psc = dnm.name;
-          break;
+          pscDnsNames.push(dnm.name.replace(/\.$/, ''));
         }
+      }
+      if (pscDnsNames.length > 0) {
+        pscDnsNames.sort((a, b) => {
+          const aIsPsc = a.toLowerCase().endsWith('.sql-psc.goog');
+          const bIsPsc = b.toLowerCase().endsWith('.sql-psc.goog');
+          if (aIsPsc && !bIsPsc) {
+            return -1;
+          }
+          if (!aIsPsc && bIsPsc) {
+            return 1;
+          }
+          return a.localeCompare(b);
+        });
+        ipAddresses.psc = pscDnsNames[0];
       }
     }
 
     // If the psc dns name was not found, use the legacy dns_name field
     if (!ipAddresses.psc && dnsName && pscEnabled) {
-      ipAddresses.psc = dnsName;
+      ipAddresses.psc = dnsName.replace(/\.$/, '');
     }
 
     if (!ipAddresses.public && !ipAddresses.private && !ipAddresses.psc) {
@@ -238,11 +252,15 @@ export class SQLAdminFetcher {
     // name in the list may be used to validate the server TLS certificate.
     // Fall back to legacy dns_name field if necessary.
     let serverName = null;
-    if (res.data.dnsNames && res.data.dnsNames.length > 0) {
-      serverName = res.data.dnsNames[0].name;
+    if (ipAddresses.psc) {
+      serverName = ipAddresses.psc;
+    } else if (res.data.dnsNames && res.data.dnsNames.length > 0) {
+      serverName = res.data.dnsNames[0].name
+        ? res.data.dnsNames[0].name.replace(/\.$/, '')
+        : null;
     }
-    if (serverName === null) {
-      serverName = res.data.dnsName;
+    if (serverName === null && res.data.dnsName) {
+      serverName = res.data.dnsName.replace(/\.$/, '');
     }
 
     return {

--- a/test/sqladmin-fetcher.ts
+++ b/test/sqladmin-fetcher.ts
@@ -208,6 +208,46 @@ t.test('getInstanceMetadata', async t => {
   );
 });
 
+t.test(
+  'getInstanceMetadata PSC auto DNS prioritization and dot trimming',
+  async t => {
+    const instanceConnectionInfo: InstanceConnectionInfo = {
+      projectId: 'my-project',
+      regionId: 'us-east1',
+      instanceId: 'my-instance',
+    };
+    mockSQLAdminGetInstanceMetadata(instanceConnectionInfo, {
+      dnsNames: [
+        {
+          name: 'abcde.12345.us-central1.sql.goog.',
+          connectionType: 'PRIVATE_SERVICE_CONNECT',
+          dnsScope: 'INSTANCE',
+        },
+        {
+          name: 'abcde.12345.us-central1.sql-psc.goog.',
+          connectionType: 'PRIVATE_SERVICE_CONNECT',
+          dnsScope: 'INSTANCE',
+        },
+      ],
+    });
+
+    const fetcher = new SQLAdminFetcher();
+    const instanceMetadata = await fetcher.getInstanceMetadata(
+      instanceConnectionInfo
+    );
+    t.same(
+      instanceMetadata.ipAddresses.psc,
+      'abcde.12345.us-central1.sql-psc.goog',
+      'should prioritize .sql-psc.goog and trim trailing dot'
+    );
+    t.same(
+      instanceMetadata.dnsName,
+      'abcde.12345.us-central1.sql-psc.goog',
+      'should set dnsName to prioritized .sql-psc.goog'
+    );
+  }
+);
+
 t.test('getInstanceMetadata custom SQL Admin API endpoint', async t => {
   const sqlAdminAPIEndpoint = 'https://sqladmin.mydomain.com';
   new SQLAdminFetcher({sqlAdminAPIEndpoint});


### PR DESCRIPTION
## Description
In `parseIpAddresses`, the connector previously broke on the first matching `dnsNames` entry, which would select the manual PSC DNS name (`.sql.goog`) if returned earlier than `.sql-psc.goog`.

This change:
- Gathers all matching PSC DNS entries, trims trailing dots, and sorts prioritizing `.sql-psc.goog`.
- Sets `ipAddresses.psc` and `serverName` to the prioritized PSC DNS name.
- Adds unit tests verifying PSC auto-DNS prioritization and dot trimming.